### PR TITLE
Postmodern

### DIFF
--- a/lib/markdown.rb
+++ b/lib/markdown.rb
@@ -1,0 +1,3 @@
+require 'kramdown'
+
+Markdown = Kramdown::Document


### PR DESCRIPTION
Added `markdown.rb` which sets the `Markdown` constant to `Kramdown::Document`. The RDiscount markdown library also does this to allow loading whichever markdown processor happens to be installed.
