### PR TITLE
obfuscation bug fix

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -253,7 +253,7 @@ module Kramdown
         res = inner(el, indent)
         attr = el.attr.dup
         if attr['href'] =~ /^mailto:/
-          attr['href'] = obfuscate('mailto') << ":" << obfuscate(attr['href'].sub(/^mailto:/, ''))
+          res = obfuscate('mailto') << ":" << obfuscate(attr['href'].sub(/^mailto:/, ''))
           res = obfuscate(res)
         end
         "<a#{html_attributes(attr)}>#{res}</a>"


### PR DESCRIPTION
Hello,
   While using your great library, I realized that the obfuscation of email addresses in html conversion was carrying over to my secondary latex conversion which caused the mailto link not to work.  I looked at the code and noticed that the element itself was being modified, and it seems that the author intended to use the local variable instead.  

To reproduce:

1.create a document with an email link 
2.doc.to_html
3.doc.to_latex

Latex doc will have a bunch of entity codes for obfuscated email
