### PR TITLE
HTML5 Compatibility for Footnotes

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -393,7 +393,7 @@ module Kramdown
           li.children = Marshal.load(Marshal.dump(data.children))
           ol.children << li
 
-          ref = Element.new(:raw, "<a href=\"#fnref:#{name}\" rev=\"footnote\">&#8617;</a>")
+          ref = Element.new(:raw, "<a href=\"#fnref:#{name}\" rel=\"reference\">&#8617;</a>")
           if li.children.last.type == :p
             para = li.children.last
           else

--- a/test/testcases/span/04_footnote/footnote_nr.html
+++ b/test/testcases/span/04_footnote/footnote_nr.html
@@ -3,10 +3,10 @@
 <div class="footnotes">
   <ol start="35">
     <li id="fn:ab">
-      <p>Some text.<a href="#fnref:ab" rev="footnote">&#8617;</a></p>
+      <p>Some text.<a href="#fnref:ab" rel="reference">&#8617;</a></p>
     </li>
     <li id="fn:bc">
-      <p>Some other text.<a href="#fnref:bc" rev="footnote">&#8617;</a></p>
+      <p>Some other text.<a href="#fnref:bc" rel="reference">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/markers.html
+++ b/test/testcases/span/04_footnote/markers.html
@@ -17,7 +17,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:fn">
-      <p>Some foot note text<a href="#fnref:fn" rev="footnote">&#8617;</a></p>
+      <p>Some foot note text<a href="#fnref:fn" rel="reference">&#8617;</a></p>
     </li>
     <li id="fn:3">
       <p>other text
@@ -26,21 +26,21 @@ with more lines</p>
       <blockquote>
         <p>and a quote</p>
       </blockquote>
-      <p><a href="#fnref:3" rev="footnote">&#8617;</a></p>
+      <p><a href="#fnref:3" rel="reference">&#8617;</a></p>
     </li>
     <li id="fn:1">
-      <p>some <em>text</em><a href="#fnref:1" rev="footnote">&#8617;</a></p>
+      <p>some <em>text</em><a href="#fnref:1" rel="reference">&#8617;</a></p>
     </li>
     <li id="fn:now">
 
       <pre><code>code block
 continued here
 </code></pre>
-      <p><a href="#fnref:now" rev="footnote">&#8617;</a></p>
+      <p><a href="#fnref:now" rel="reference">&#8617;</a></p>
     </li>
     <li id="fn:empty">
 
-      <p><a href="#fnref:empty" rev="footnote">&#8617;</a></p>
+      <p><a href="#fnref:empty" rel="reference">&#8617;</a></p>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
The link that renders with footnotes to jump back to the main content uses the "rev" attribute, which has been removed in HTML5 (see http://www.google.com/search?sourceid=chrome&ie=UTF-8&q=html5+rev+attribute). The recommendation is to use the "rel" attribute with a name meaning the opposite of it's partner "rel" attribute. Therefore, since the footnote link has rel="footnote" I changed the return link to rel="reference". Can you think of a better value for this?

Thanks!
