### PR TITLE
span tags must have a separate closing tag to be valid HTML.

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -178,7 +178,7 @@ module Kramdown
       end
 
       # A list of all HTML tags that need to have a body (even if the body is empty).
-      HTML_TAGS_WITH_BODY=['div', 'script', 'iframe', 'textarea', 'a'] # :nodoc:
+      HTML_TAGS_WITH_BODY=['div', 'span', 'script', 'iframe', 'textarea', 'a'] # :nodoc:
 
       def convert_html_element(el, indent)
         res = inner(el, indent)

--- a/test/testcases/span/05_html/normal.html
+++ b/test/testcases/span/05_html/normal.html
@@ -15,7 +15,9 @@ now </span>.</p>
 <p>This is <span>tag
 </span> now.</p>
 
-<p>This is <em>something<span test="do_it" /> strange</em>.</p>
+<p>This is an empty <span></span> tag.</p>
+
+<p>This is <em>something<span test="do_it"></span> strange</em>.</p>
 
 <p>Auto-closing: <br /></p>
 

--- a/test/testcases/span/05_html/normal.text
+++ b/test/testcases/span/05_html/normal.text
@@ -15,6 +15,8 @@ now </span>.
 This is <span>tag
 </span> now.
 
+This is an empty <span></span> tag.
+
 This is _something<span test="do_it" /> strange_.
 
 Auto-closing: <br>


### PR DESCRIPTION
"&lt;span /&gt;" is invalid markup in HTML 4 and 5, but valid in XHTML.
"&lt;span&gt;&lt;/span&gt;" is valid in all three, so it should be used instead.
