### PR TITLE
Fixed a typo. --output not --ouput

### DIFF
--- a/bin/kramdown
+++ b/bin/kramdown
@@ -35,7 +35,7 @@ OptionParser.new do |opts|
   opts.separator ""
 
   opts.on("-i", "--input ARG", "Specify the input format: kramdown (default) or html") {|v| options[:input] = v}
-  opts.on("-o", "--ouput ARG", "Specify the output format: html (default), kramdown or latex") {|v| format = v}
+  opts.on("-o", "--output ARG", "Specify the output format: html (default), kramdown or latex") {|v| format = v}
 
   opts.on("-v", "--version", "Show the version of kramdown") do
     puts Kramdown::VERSION


### PR DESCRIPTION
Fixed a typo in the kramdown options.
