### PR TITLE
Fix Document#method_missing to accept snake_cased class name

### DIFF
--- a/lib/kramdown/document.rb
+++ b/lib/kramdown/document.rb
@@ -98,7 +98,7 @@ module Kramdown
     #
     # For example, +to_html+ would instantiate the Kramdown::Converter::Html class.
     def method_missing(id, *attr, &block)
-      if id.to_s =~ /^to_(\w+)$/ && (name = $1[0..0].upcase + $1[1..-1]) && Converter.const_defined?(name)
+      if id.to_s =~ /^to_(\w+)$/ && (name = method_to_class_name($1)) && Converter.const_defined?(name)
         output, warnings = Converter.const_get(name).convert(@root, @options)
         @warnings.concat(warnings)
         output
@@ -109,6 +109,11 @@ module Kramdown
 
     def inspect #:nodoc:
       "<KD:Document: options=#{@options.inspect} root=#{@root.inspect} warnings=#{@warnings.inspect}>"
+    end
+
+    private
+    def method_to_class_name(name)
+      name.split('_').inject(''){ |s,x| s << x[0..0].upcase + x[1..-1] }
     end
 
   end


### PR DESCRIPTION
When doc.to_my_converter is called, it should use MyConverter, but used My_converter
