### PR TITLE
Fix unit-test for Coderay

### DIFF
--- a/test/testcases/block/12_extension/options3.html
+++ b/test/testcases/block/12_extension/options3.html
@@ -1,7 +1,7 @@
-<div><span class="CodeRay">x = <span class="constant">Class</span>.new
+<div><span class="CodeRay">x = <span class="co">Class</span>.new
 </span>
 </div>
 
-<div><span class="CodeRay">x = <span class="constant">Class</span>.new
+<div><span class="CodeRay">x = <span class="co">Class</span>.new
 </span>
 </div>


### PR DESCRIPTION
Newer Coderay return 'class="co"' instead of 'class="constant"'.
This patch fix it.

Signed-off-by: Youhei SASAKI uwabami@gfd-dennou.org
