### PR TITLE
Adds the ability to offset levels of all <Hx> headings so the markup doesn't have to start at <h1> as top header

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -144,7 +144,8 @@ module Kramdown
           attr['id'] = generate_id(el.options[:raw_text])
         end
         @toc << [el.options[:level], attr['id'], el.children] if attr['id'] && in_toc?(el)
-        "#{' '*indent}<h#{el.options[:level]}#{html_attributes(attr)}>#{inner(el, indent)}</h#{el.options[:level]}>\n"
+        output_level = Integer(el.options[:level])+@options[:header_offset].to_i
+        "#{' '*indent}<h#{output_level}#{html_attributes(attr)}>#{inner(el, indent)}</h#{output_level}>\n"
       end
 
       def convert_hr(el, indent)

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -401,6 +401,16 @@ Default: false
 Used by: RemoveHtmlTags converter
 EOF
 
+    define(:header_offset, Integer, 0, <<EOF)
+Sets the offset for <h1> <h2>... headers
+
+If this option is c then writing markdown code that translates
+to <Hn> would translate to <H(n+c)>
+
+Default: 0
+Used by: HTML converter
+EOF
+
   end
 
 end

--- a/test/testcases/block/04_header/header_type_offset.html
+++ b/test/testcases/block/04_header/header_type_offset.html
@@ -1,0 +1,9 @@
+<h2>Lorem ipsum</h2>
+
+<h3>Lorem ipsum</h3>
+
+<h4>Lorem ipsum</h4>
+
+<h2>Lorem ipsum</h2>
+
+<h3>Lorem ipsum</h3>

--- a/test/testcases/block/04_header/header_type_offset.options
+++ b/test/testcases/block/04_header/header_type_offset.options
@@ -1,0 +1,2 @@
+:header_offset: 1
+:auto_ids: false

--- a/test/testcases/block/04_header/header_type_offset.text
+++ b/test/testcases/block/04_header/header_type_offset.text
@@ -1,0 +1,11 @@
+# Lorem ipsum
+
+## Lorem ipsum
+
+### Lorem ipsum
+
+Lorem ipsum
+===========
+
+Lorem ipsum
+-----------


### PR DESCRIPTION
This is suitable anytime you are not writing a whole document in Markdown but just a part of it. An example might be a blog post, where the h1 tag is generated elsewhere by the template system, or even the h1 is the site logo, h2 the article title (generated elsewhere outside the article) so the article itself uses headers starting at h3.
