### PR TITLE
Convert HMTL entities in abbreviation titles

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -322,7 +322,7 @@ module Kramdown
 
       def convert_abbreviation(el, indent)
         title = @root.options[:abbrev_defs][el.value]
-        "<abbr#{!title.empty? ? " title=\"#{title}\"" : ''}>#{el.value}</abbr>"
+        "<abbr#{!title.empty? ? html_attributes(:title => title) : ''}>#{el.value}</abbr>"
       end
 
       def convert_root(el, indent)

--- a/test/testcases/span/abbreviations/abbrev.html
+++ b/test/testcases/span/abbreviations/abbrev.html
@@ -1,6 +1,6 @@
 <p>This <abbr title="It is, yes">is some</abbr> text.</p>
 
-<p>There <em><abbr title="It is, yes">is some</abbr> real</em> concern about <abbr title="Other">OtHeR!</abbr></p>
+<p>There <em><abbr title="It is, yes">is some</abbr> real</em> concern about <abbr title="This &amp; that">OtHeR!</abbr></p>
 
 <p><abbr title="It is, yes">is some</abbr> Think <abbr>empty</abbr> about <abbr title="Very nice country">Österreich</abbr>.</p>
 

--- a/test/testcases/span/abbreviations/abbrev.text
+++ b/test/testcases/span/abbreviations/abbrev.text
@@ -1,7 +1,7 @@
 This is some text.
 
 *[is some]: Yes it is  
-*[OtHeR!]: Other
+*[OtHeR!]: This & that
 
 *[is some]: It is, yes  
 *[empty]:


### PR DESCRIPTION
Previously if entities in abbreviation titles had reserved HTML characters in them (e.g. &), these weren't converted to entities.  This causes errors when processing the resulting markup in Nokogiri and the like.
