### PR TITLE
Use numeric entities as default fallback if `:as_code` is not available

### DIFF
--- a/lib/kramdown/utils/html.rb
+++ b/lib/kramdown/utils/html.rb
@@ -43,10 +43,10 @@ module Kramdown
           c
         elsif (entity_output == :as_input || entity_output == :as_char) && original
           original
-        elsif entity_output == :numeric || e.name.nil?
-          "&##{e.code_point};"
-        else
+        elsif entity_output == :symbolic && !e.name.nil?
           "&#{e.name};"
+        else # default to :numeric
+          "&##{e.code_point};"
         end
       end
 


### PR DESCRIPTION
This series of commits makes `:numeric` the default fallback for entity output in case it is not possible to output entities `:as_code` (only possible in MRI 1.9 and VM with `String#encode`).

The current default fallback is `:symbolic`. Symbolic entities are allowed only in loose HTML; XHTML and XML documents cannot use them without preprocessing or workarounds. Numeric entities, on the other hand, can be used without problems HTML, XHTML and XML without modifications.

Please note that I have not changed the associated tests; I do not know if you prefer to keep the existing tests and add `.options` files or change the expected texts.
