### PR TITLE
support disable coderay

### DIFF
--- a/doc/converter/html.page
+++ b/doc/converter/html.page
@@ -96,6 +96,8 @@ Here is an example on how Ruby code is highlighted:
     puts 1 + 1
 {: lang='ruby'}
 
+You can use set option `:enable_coderay` to `false` to disable this feature, leaving a clean source.
+
 
 ## Math Support
 
@@ -137,7 +139,7 @@ Here is an example:
 
 The HTML converter supports the following options:
 
-{options: {items: [:auto_ids, :template, :footnote_nr, :entity_output, :smart_quotes, :toc_levels, :coderay_wrap, :coderay_line_numbers, :coderay_line_number_start, :coderay_tab_width, :coderay_bold_every, :coderay_css, :coderay_default_lang]}}
+{options: {items: [:auto_ids, :template, :footnote_nr, :entity_output, :smart_quotes, :toc_levels, :enable_coderay, :coderay_wrap, :coderay_line_numbers, :coderay_line_number_start, :coderay_tab_width, :coderay_bold_every, :coderay_css, :coderay_default_lang]}}
 
 
 {include_file: doc/links.markdown}

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -64,6 +64,7 @@ module Kramdown
         @toc_code = nil
         @indent = 2
         @stack = []
+        @enable_coderay = @options[:enable_coderay] && HIGHLIGHTING_AVAILABLE
       end
 
       # The mapping of element type to conversion method.
@@ -108,30 +109,33 @@ module Kramdown
       end
 
       def convert_codeblock(el, indent)
-        if (el.attr['lang'] || @options[:coderay_default_lang]) && HIGHLIGHTING_AVAILABLE
-          attr = el.attr.dup
+        attr = el.attr.dup
+        if @enable_coderay && (el.attr['lang'] || @options[:coderay_default_lang])
           opts = {:wrap => @options[:coderay_wrap], :line_numbers => @options[:coderay_line_numbers],
             :line_number_start => @options[:coderay_line_number_start], :tab_width => @options[:coderay_tab_width],
             :bold_every => @options[:coderay_bold_every], :css => @options[:coderay_css]}
           lang = (attr.delete('lang') || @options[:coderay_default_lang]).to_sym
           result = CodeRay.scan(el.value, lang).html(opts).chomp << "\n"
-          "#{' '*indent}<div#{html_attributes(attr)}>#{result}#{' '*indent}</div>\n"
-        else
-          result = escape_html(el.value)
-          result.chomp!
-          if el.attr['class'].to_s =~ /\bshow-whitespaces\b/
-            result.gsub!(/(?:(^[ \t]+)|([ \t]+$)|([ \t]+))/) do |m|
-              suffix = ($1 ? '-l' : ($2 ? '-r' : ''))
-              m.scan(/./).map do |c|
-                case c
-                when "\t" then "<span class=\"ws-tab#{suffix}\">\t</span>"
-                when " " then "<span class=\"ws-space#{suffix}\">&#8901;</span>"
-                end
-              end.join('')
-            end
-          end
-          "#{' '*indent}<pre#{html_attributes(el.attr)}><code>#{result}\n</code></pre>\n"
+          return "#{' '*indent}<div#{html_attributes(attr)}>#{result}#{' '*indent}</div>\n"
         end
+        if lang = el.attr['lang'] || @options[:coderay_default_lang]
+          attr.delete('lang')
+          self.class.add_attr_class(attr, lang)
+        end
+        result = escape_html(el.value)
+        result.chomp!
+        if el.attr['class'].to_s =~ /\bshow-whitespaces\b/
+          result.gsub!(/(?:(^[ \t]+)|([ \t]+$)|([ \t]+))/) do |m|
+            suffix = ($1 ? '-l' : ($2 ? '-r' : ''))
+            m.scan(/./).map do |c|
+              case c
+              when "\t" then "<span class=\"ws-tab#{suffix}\">\t</span>"
+              when " " then "<span class=\"ws-space#{suffix}\">&#8901;</span>"
+              end
+            end.join('')
+          end
+        end
+        "#{' '*indent}<pre#{html_attributes(attr)}><code>#{result}\n</code></pre>\n"
       end
 
       def convert_blockquote(el, indent)
@@ -266,13 +270,16 @@ module Kramdown
       end
 
       def convert_codespan(el, indent)
-        if el.attr['lang'] && HIGHLIGHTING_AVAILABLE
-          attr = el.attr.dup
+        attr = el.attr.dup
+        if @enable_coderay && (el.attr['lang'] || @options[:coderay_default_lang])          
           result = CodeRay.scan(el.value, attr.delete('lang').to_sym).html(:wrap => :span, :css => @options[:coderay_css]).chomp
-          "<code#{html_attributes(attr)}>#{result}</code>"
-        else
-          "<code#{html_attributes(el.attr)}>#{escape_html(el.value)}</code>"
+          return "<code#{html_attributes(attr)}>#{result}</code>"
         end
+        if lang = el.attr['lang'] || @options[:coderay_default_lang]
+          attr.delete('lang')
+          self.class.add_attr_class(attr, lang)
+        end
+        "<code#{html_attributes(attr)}>#{escape_html(el.value)}</code>"
       end
 
       def convert_footnote(el, indent)
@@ -414,6 +421,15 @@ module Kramdown
           para.children << ref
         end
         (ol.children.empty? ? '' : "<div class=\"footnotes\">\n#{convert(ol, 2)}</div>\n")
+      end
+
+
+      class << self
+        def add_attr_class(attr, klass)
+          vals = attr['class'] ? attr['class'].strip.split(' ') : []
+          vals = vals.concat([klass]).flatten.uniq
+          attr['class'] = vals.join(' ')
+        end
       end
 
     end

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -243,6 +243,15 @@ Default: 1
 Used by: HTML converter
 EOF
 
+    define(:enable_coderay, Boolean, true, <<EOF)
+Determines whether to use Coderay
+
+The possible values are true or false.
+
+Default: true
+Used by: HTML converter
+EOF
+
     define(:coderay_wrap, Symbol, :div, <<EOF)
 Defines how the highlighted code should be wrapped
 

--- a/test/testcases/block/06_codeblock/disable-highlighting.html
+++ b/test/testcases/block/06_codeblock/disable-highlighting.html
@@ -1,0 +1,4 @@
+<pre><code>x = Class.new
+</code></pre>
+<pre class="html"><code>&lt;a&gt;href&lt;/a&gt;
+</code></pre>

--- a/test/testcases/block/06_codeblock/disable-highlighting.options
+++ b/test/testcases/block/06_codeblock/disable-highlighting.options
@@ -1,0 +1,1 @@
+:enable_coderay: false

--- a/test/testcases/block/06_codeblock/disable-highlighting.text
+++ b/test/testcases/block/06_codeblock/disable-highlighting.text
@@ -1,0 +1,4 @@
+    x = Class.new
+^
+    <a>href</a>
+{: lang="html"}


### PR DESCRIPTION
- add option `:enable_coderay`, which can be used to disable coderay.
  the default vaule is `true` to be compatible with current behavior
- add content about it in doc
