### PR TITLE
Exclude headers from TOC using the `notoc` ref.

### DIFF
--- a/doc/converter/html.page
+++ b/doc/converter/html.page
@@ -126,9 +126,15 @@ was applied to an unordered list or else as nested ordered lists. All attributes
 original list will also be applied to the generated TOC list and it will get an ID of `markdown-toc`
 if no ID was set.
 
+When the `auto_ids` option is set, all headers will appear in the table of contents as they all will
+have an ID. Assign the class name "no_toc" to a header to exclude it from the table of contents.
+
 Here is an example:
 
-    * Will be replaced with the ToC
+    # Contents
+    {:.no_toc}
+
+    * Will be replaced with the ToC, excluding the "Contents" header
     {:toc}
 
     # H1 header

--- a/lib/kramdown/converter/base.rb
+++ b/lib/kramdown/converter/base.rb
@@ -132,7 +132,7 @@ module Kramdown
       # Return +true+ if the header element +el+ should be used for the table of contents (as
       # specified by the +toc_levels+ option).
       def in_toc?(el)
-        @options[:toc_levels].include?(el.options[:level])
+        @options[:toc_levels].include?(el.options[:level]) and ((not el.attr['class'].split.include?('no_toc')) rescue true)
       end
 
       # Return the output header level given a level.

--- a/test/testcases/block/16_toc/toc_exclude.html
+++ b/test/testcases/block/16_toc/toc_exclude.html
@@ -1,0 +1,35 @@
+<h1 class="no_toc" id="contents">Contents</h1>
+
+<ul id="markdown-toc">
+  <li><a href="#header-level-1">Header level 1</a>    <ul>
+      <li><a href="#header-level-2">Header level 2</a>        <ul>
+          <li><a href="#header-level-3">Header level 3</a>            <ul>
+              <li><a href="#header-level-4">Header level 4</a></li>
+            </ul>
+          </li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+  <li><a href="#other-header-level-1">Other header level 1</a>    <ul>
+      <li><a href="#other-header-level-2">Other header level 2</a>        <ul>
+          <li><a href="#other-header-level-3">Other header level 3</a></li>
+        </ul>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+<h1 id="header-level-1">Header level 1</h1>
+
+<h2 id="header-level-2">Header level 2</h2>
+
+<h3 id="header-level-3">Header level 3</h3>
+
+<h4 id="header-level-4">Header level 4</h4>
+
+<h1 id="other-header-level-1">Other header level 1</h1>
+
+<h2 id="other-header-level-2">Other header level 2</h2>
+
+<h3 id="other-header-level-3">Other header level 3</h3>

--- a/test/testcases/block/16_toc/toc_exclude.options
+++ b/test/testcases/block/16_toc/toc_exclude.options
@@ -1,0 +1,1 @@
+:auto_ids: true

--- a/test/testcases/block/16_toc/toc_exclude.text
+++ b/test/testcases/block/16_toc/toc_exclude.text
@@ -1,0 +1,19 @@
+# Contents
+{:.no_toc}
+
+* Here comes the table of content
+{:toc}
+
+# Header level 1
+
+## Header level 2
+
+### Header level 3
+
+#### Header level 4
+
+# Other header level 1
+
+## Other header level 2
+
+### Other header level 3


### PR DESCRIPTION
When `auto_ids` is set, all headers receive an ID and therefore appear in the table of contents. This patch causes applying {:notoc} to a header to exclude it from the table of contents. This is useful for e.g. preventing the TOC from including a link to its own header.
