### PR TITLE
Fix bug: handle "|" in $$..$$ or <code>..</code>

### DIFF
--- a/lib/kramdown/parser/kramdown/table.rb
+++ b/lib/kramdown/parser/kramdown/table.rb
@@ -39,7 +39,7 @@ module Kramdown
       TABLE_HSEP_ALIGN = /[ ]?(:?)-+(:?)[ ]?/
       TABLE_FSEP_LINE = /^[+|: =]*?=[+|: =]*?[ \t]*\n/
       TABLE_ROW_LINE = /^(.*?)[ \t]*\n/
-      TABLE_PIPE_CHECK = /(?:\||#{NOT_ELEM_OPEN}*(?:#{ELEM}#{NOT_ELEM_OPEN_OR_NL}*)*\|)/
+      TABLE_PIPE_CHECK = /(?:\||#{NOT_ELEM_OPEN}*(?:#{ELEM}#{NOT_ELEM_OPEN_OR_NL}*)*(?<!\\)\|)/
       TABLE_LINE = /#{TABLE_PIPE_CHECK}.*?\n/
       TABLE_START = /^#{OPT_SPACE}(?=\S)#{TABLE_LINE}/
 


### PR DESCRIPTION
Given the following input kramdown input:

```
Codeblock:

<code>code|block</code>

Inline code: <code>some|code</code>

Code in table:

| <code>this | is</code> | <code>a | test</code>|

Formula:

$$ P(x) = \sum_z P(x|z)P(z) $$

Inline formula: $$ P(x) = \sum_z P(x|z)P(z) $$

Formula in table:

| $$P(x|y)$$ | $$P(y|z)$$|
```

Previously, kramdown would give the wrong output:

``` HTML
<p>Codeblock:</p>

<table>
  <tbody>
    <tr>
      <td><code>code|block</code></td>
    </tr>
  </tbody>
</table>

<table>
  <tbody>
    <tr>
      <td>Inline code: <code>some|code</code></td>
    </tr>
  </tbody>
</table>

<p>Code in table:</p>

<table>
  <tbody>
    <tr>
      <td><code>this | is</code></td>
      <td><code>a | test</code></td>
    </tr>
  </tbody>
</table>

<p>Formula:</p>

<table>
  <tbody>
    <tr>
      <td>$$ P(x) = \sum_z P(x</td>
      <td>z)P(z) $$</td>
    </tr>
  </tbody>
</table>

<table>
  <tbody>
    <tr>
      <td>Inline formula: $$ P(x) = \sum_z P(x</td>
      <td>z)P(z) $$</td>
    </tr>
  </tbody>
</table>

<p>Formula in table:</p>

<table>
  <tbody>
    <tr>
      <td>$$P(x</td>
      <td>y)$$</td>
      <td>$$P(y</td>
      <td>z)$$</td>
    </tr>
  </tbody>
</table>
```

After the bugfix, the output is:

``` HTML
<p>Codeblock:</p>

<p><code>code|block</code></p>

<p>Inline code: <code>some|code</code></p>

<p>Code in table:</p>

<table>
  <tbody>
    <tr>
      <td><code>this | is</code></td>
      <td><code>a | test</code></td>
    </tr>
  </tbody>
</table>

<p>Formula:</p>

<script type="math/tex; mode=display"> P(x) = \sum_z P(x|z)P(z) </script>

<p>Inline formula: <script type="math/tex"> P(x) = \sum_z P(x|z)P(z) </script></p>

<p>Formula in table:</p>

<table>
  <tbody>
    <tr>
      <td><script type="math/tex">P(x|y)</script></td>
      <td><script type="math/tex">P(y|z)</script></td>
    </tr>
  </tbody>
</table>
```
