### PR TITLE
Add Gemfile/Gemspec to Allow for Git-Based Bundler Installs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Just a pointer to the gemspec
+gemspec

--- a/kramdown.gemspec
+++ b/kramdown.gemspec
@@ -1,0 +1,19 @@
+# -*- encoding: utf-8 -*-
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'kramdown/version'
+
+Gem::Specification.new do |gem|
+  gem.name          = "kramdown"
+  gem.version       = Kramdown::VERSION
+  gem.authors       = ["Thomas Leitner"]
+  gem.email         = ["t_leitner@gmx.at"]
+  gem.description   = %q{A free GPL-licensed Ruby library for parsing and converting a superset of Markdown}
+  gem.summary       = %q{kramdown is first and foremost a library for converting text written in a superset of Markdown to HTML. However, due to its modular architecture it is able to support additional input and output formats.}
+  gem.homepage      = "http://kramdown.rubyforge.org/"
+
+  gem.files         = `git ls-files`.split($/)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = ["lib"]
+end


### PR DESCRIPTION
This resolves bundlers complains when specifying kramdown installation from a specific git repo:

Bundler whines when specifying that Kramdown should be installed via git:

``` ruby
gem 'kramdown', :git => 'https://github.com/gettalong/kramdown.git'
```

> Could not find gem 'kramdown (>= 0) ruby' in https://github.com/gettalong/kramdown.git (at master).
> Source does not contain any versions of 'kramdown (>= 0) ruby'
