### PR TITLE
Fixed deprecated method call in list parser

### DIFF
--- a/lib/kramdown/parser/kramdown/list.rb
+++ b/lib/kramdown/parser/kramdown/list.rb
@@ -214,7 +214,7 @@ module Kramdown
           else
             last = nil
           end
-          if it.children.first.type == :p && !it.options.delete(:first_as_para)
+          if it.children.first.class == :p && !it.options.delete(:first_as_para)
             it.children.first.children.first.value << "\n" if it.children.size > 1
             it.children.first.options[:transparent] = true
           end


### PR DESCRIPTION
The current code produces a deprecated warning in Ruby 1.8 and fails in Ruby 1.9 when parsing a definition list.  This is due to use of a .type method. I've changed this to .class which fixes the problem.
