### PR TITLE
Remove trailing whitespace in produced markdown

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -366,7 +366,7 @@ module Kramdown
         res << "\n\n" if @linkrefs.size > 0
         @linkrefs.each_with_index do |el, i|
           title = el.attr['title']
-          res << "[#{i+1}]: #{el.attr['href']} #{title ? '"' + title.gsub(/"/, "&quot;") + '"' : ''}\n"
+          res << "[#{i+1}]: #{el.attr['href']}#{title ? ' "' + title.gsub(/"/, "&quot;") + '"' : ''}\n"
         end
         res
       end


### PR DESCRIPTION
Avoids a trailing whitespace in link definitions without a title when converting to markdown (kramdown) format:

```
require 'kramdown'
htmldoc =<<HTML
<p><a href="http://test1.com/">Test 1</a></p>
<p><a href="http://test2.com/" title="Test 2">Test 2</a></p>
HTML
puts Kramdown::Document.new(htmldoc, :input => :html).to_kramdown
```

Output:

```
[Test 1][1]

[Test 2][2]



[1]: http://test1.com/X
[2]: http://test2.com/ "Test 2"
```

with a whitespace (marked by "X") at the end of link definition 1.
