### PR TITLE
Nonbreaking space in LaTeX is '~'

### DIFF
--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -404,7 +404,7 @@ module Kramdown
         402 => ['\textflorin', 'mathcomp'],
         381 => ['\v{Z}'],
         382 => ['\v{z}'],
-        160 => ['\nolinebreak'],
+        160 => ['~'],
         161 => ['\textexclamdown'],
         163 => ['\pounds'],
         164 => ['\currency', 'wasysym'],


### PR DESCRIPTION
LaTeX chokes on \nolinebreak{} if there is no line to end. ~ adds a 'normal' space, makes no trouble with empty lines, and generally fits the concept of a non-breaking space.
