### PR TITLE
Implement abbreviations in the LaTeX converter

### DIFF
--- a/data/kramdown/document.latex
+++ b/data/kramdown/document.latex
@@ -36,6 +36,11 @@ encmap = {
 \VerbatimFootnotes
 <% end %>
 
+<% if @converter.data[:packages].include?('acronym') %>
+<% @converter.root.options[:abbrev_defs].each_pair {|k,v| %>\acrodef{<%= k %>}{<%= v %>}
+<% } %>
+<% end %>
+
 \hypersetup{colorlinks=true,urlcolor=blue}
 
 \begin{document}

--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -545,7 +545,8 @@ module Kramdown
       end
 
       def convert_abbreviation(el, opts)
-        el.value
+        @data[:packages] += %w[acronym]
+        "\\ac{#{el.value}}"
       end
 
       # Wrap the +text+ inside a LaTeX environment of type +type+. The element +el+ is passed on to


### PR DESCRIPTION
This pull requests adds abbreviation functionality to the LaTeX converter by using the acronyms package. The document template has been modified as well to generate the necessary acronym definitions (albeit without generating a list of acronyms).
