### PR TITLE
Correctly convert elements with trailing whitespace to LaTeX

### DIFF
--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -145,10 +145,10 @@ module Kramdown
       end
 
       def convert_html_element(el, opts)
-        if el.value == 'i'
+        if el.value == 'i' || el.value == 'em'
           "\\emph{#{inner(el, opts)}}"
-        elsif el.value == 'b'
-          "\\emph{#{inner(el, opts)}}"
+        elsif el.value == 'b' || el.value == 'strong'
+          "\\textbf{#{inner(el, opts)}}"
         else
           warning("Can't convert HTML element")
           ''


### PR DESCRIPTION
This would fix issue #65.
