### PR TITLE
URLs in a['href'] should be escaped for LaTeX

### DIFF
--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -206,9 +206,9 @@ module Kramdown
       def convert_a(el, opts)
         url = el.attr['href']
         if url =~ /^#/
-          "\\hyperlink{#{url[1..-1]}}{#{inner(el, opts)}}"
+          "\\hyperlink{#{escape(url[1..-1])}}{#{inner(el, opts)}}"
         else
-          "\\href{#{url}}{#{inner(el, opts)}}"
+          "\\href{#{escape(url)}}{#{inner(el, opts)}}"
         end
       end
 


### PR DESCRIPTION
An URL such as in a `a['href']` can contain URL escape codes, which all start with a `%`. The LaTeX-converter should escape all `%` to `\%` using `escape()`, or otherwise the unescaped `%` will be treated like a comment in LaTeX, corrupting the file.

This pull request fixes this by calling `escape()` on the URL.
