### PR TITLE
Parse header IDs according to HTML4 spec

### DIFF
--- a/lib/kramdown/parser/kramdown/header.rb
+++ b/lib/kramdown/parser/kramdown/header.rb
@@ -13,7 +13,7 @@ module Kramdown
   module Parser
     class Kramdown
 
-      HEADER_ID=/(?:[ \t]+\{#(\w[\w-]*)\})?/
+      HEADER_ID=/(?:[ \t]+\{#([A-Za-z][A-Za-z0-9_:.-]*)\})?/
       SETEXT_HEADER_START = /^(#{OPT_SPACE}[^ \t].*?)#{HEADER_ID}[ \t]*?\n(-|=)+\s*?\n/
 
       # Parse the Setext header at the current location.

--- a/test/testcases/block/04_header/atx_header.html
+++ b/test/testcases/block/04_header/atx_header.html
@@ -38,6 +38,10 @@
 
 <h3 id="id">Header</h3>
 
+<h3 id="id-with-dashes">Header</h3>
+
+<h3 id="id:with-colon">Header</h3>
+
 <h3>Header{#noid}</h3>
 
 <h3>Header ##{#noid}</h3>

--- a/test/testcases/block/04_header/atx_header.text
+++ b/test/testcases/block/04_header/atx_header.text
@@ -36,6 +36,10 @@ paragraph
 
 ### Header    ##    {#id}
 
+### Header {#id-with-dashes}
+
+### Header {#id:with-colon}
+
 ### Header{#noid}
 
 ### Header ##{#noid}


### PR DESCRIPTION
Includes colons, underscores, dots and hyphens.

This fixes gettalong#72.
