### PR TITLE
templatename extensions supports snake_case. Was: downcase

### DIFF
--- a/lib/kramdown/converter/base.rb
+++ b/lib/kramdown/converter/base.rb
@@ -129,7 +129,7 @@ module Kramdown
 
       # Return the template specified by +template+.
       def self.get_template(template) # :nodoc:
-        format_ext = '.' + self.name.split(/::/).last.downcase
+        format_ext = '.' + ::Kramdown::Utils.snake_case(self.name.split(/::/).last)
         shipped = File.join(::Kramdown.data_dir, template + format_ext)
         if File.exist?(template)
           File.read(template)


### PR DESCRIPTION
Subclassing a converter like `class LatexFoo < Latex` now looks for
template with extension `latex_foo` instead `latexfoo`. More conform
with the already existing method `to_latex_foo` .

To implementation might be too messy in order to keep backwards compatibility? 
