### PR TITLE
Added location information to Kramdown::Element.

### DIFF
--- a/lib/kramdown/element.rb
+++ b/lib/kramdown/element.rb
@@ -459,6 +459,9 @@ module Kramdown
   #
   # The option :type can be set to an array of strings to define for which converters the raw string
   # is valid.
+  #
+  # The option :location may contain the start line number of this element in the
+  # source document.
   class Element
 
     # A symbol representing the element type. For example, :p or :blockquote.

--- a/lib/kramdown/parser/base.rb
+++ b/lib/kramdown/parser/base.rb
@@ -7,6 +7,8 @@
 #++
 #
 
+require 'kramdown/string_scanner_kramdown' # for location information
+
 module Kramdown
 
   module Parser
@@ -14,7 +16,7 @@ module Kramdown
     # == \Base class for parsers
     #
     # This class serves as base class for parsers. It provides common methods that can/should be
-    # used by all parsers, especially by those using StringScanner for parsing.
+    # used by all parsers, especially by those using StringScanner(Kramdown) for parsing.
     #
     # A parser object is used as a throw-away object, i.e. it is only used for storing the needed
     # state information during parsing. Therefore one can't instantiate a parser object directly but
@@ -49,7 +51,7 @@ module Kramdown
       def initialize(source, options)
         @source = source
         @options = Kramdown::Options.merge(options)
-        @root = Element.new(:root, nil, nil, :encoding => (source.encoding rescue nil))
+        @root = Element.new(:root, nil, nil, :encoding => (source.encoding rescue nil), :location => 1)
         @warnings = []
         @text_type = :text
       end

--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -243,7 +243,7 @@ module Kramdown
         # entities in entity elements.
         def process_text(raw, preserve = false)
           raw.gsub!(/\s+/, ' ') unless preserve
-          src = StringScanner.new(raw)
+          src = StringScannerKramdown.new(raw)
           result = []
           while !src.eos?
             if tmp = src.scan_until(/(?=#{HTML_ENTITY_RE})/)
@@ -533,7 +533,7 @@ module Kramdown
       # Parse the source string provided on initialization as HTML document.
       def parse
         @stack, @tree = [], @root
-        @src = StringScanner.new(adapt_source(source))
+        @src = StringScannerKramdown.new(adapt_source(source))
 
         while true
           if result = @src.scan(/\s*#{HTML_INSTRUCTION_RE}/)

--- a/lib/kramdown/parser/kramdown/abbreviation.rb
+++ b/lib/kramdown/parser/kramdown/abbreviation.rb
@@ -15,10 +15,11 @@ module Kramdown
 
       # Parse the link definition at the current location.
       def parse_abbrev_definition
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
         abbrev_id, abbrev_text = @src[1], @src[2]
         abbrev_text.strip!
-        warning("Duplicate abbreviation ID '#{abbrev_id}' - overwriting") if @root.options[:abbrev_defs][abbrev_id]
+        warning("Duplicate abbreviation ID '#{abbrev_id}' on line #{start_line_number} - overwriting") if @root.options[:abbrev_defs][abbrev_id]
         @root.options[:abbrev_defs][abbrev_id] = abbrev_text
         @tree.children << Element.new(:eob, :abbrev_def)
         true
@@ -37,7 +38,7 @@ module Kramdown
           if child.type == :text
             if child.value =~ regexps.first
               result = []
-              strscan = StringScanner.new(child.value)
+              strscan = StringScannerKramdown.new(child.value)
               while temp = strscan.scan_until(regexps.last)
                 abbr = strscan.scan(regexps.first) # begin of line case of abbr with \W char as first one
                 if abbr.nil?

--- a/lib/kramdown/parser/kramdown/autolink.rb
+++ b/lib/kramdown/parser/kramdown/autolink.rb
@@ -23,9 +23,10 @@ module Kramdown
 
       # Parse the autolink at the current location.
       def parse_autolink
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
         href = (@src[2].nil? ? "mailto:#{@src[1]}" : @src[1])
-        el = Element.new(:a, nil, {'href' => href})
+        el = Element.new(:a, nil, {'href' => href}, :location => start_line_number)
         add_text(@src[1].sub(/^mailto:/, ''), el)
         @tree.children << el
       end

--- a/lib/kramdown/parser/kramdown/blockquote.rb
+++ b/lib/kramdown/parser/kramdown/blockquote.rb
@@ -19,13 +19,14 @@ module Kramdown
 
       # Parse the blockquote at the current location.
       def parse_blockquote
+        start_line_number = @src.current_line_number
         result = @src.scan(PARAGRAPH_MATCH)
         while !@src.match?(self.class::LAZY_END)
           result << @src.scan(PARAGRAPH_MATCH)
         end
         result.gsub!(BLOCKQUOTE_START, '')
 
-        el = new_block_el(:blockquote)
+        el = new_block_el(:blockquote, nil, nil, :location => start_line_number)
         @tree.children << el
         parse_blocks(el, result)
         true

--- a/lib/kramdown/parser/kramdown/codeblock.rb
+++ b/lib/kramdown/parser/kramdown/codeblock.rb
@@ -21,10 +21,11 @@ module Kramdown
 
       # Parse the indented codeblock at the current location.
       def parse_codeblock
+        start_line_number = @src.current_line_number
         data = @src.scan(self.class::CODEBLOCK_MATCH)
         data.gsub!(/\n( {0,3}\S)/, ' \\1')
         data.gsub!(INDENT, '')
-        @tree.children << new_block_el(:codeblock, data)
+        @tree.children << new_block_el(:codeblock, data, nil, :location => start_line_number)
         true
       end
       define_parser(:codeblock, CODEBLOCK_START)
@@ -36,8 +37,9 @@ module Kramdown
       # Parse the fenced codeblock at the current location.
       def parse_codeblock_fenced
         if @src.check(self.class::FENCED_CODEBLOCK_MATCH)
+          start_line_number = @src.current_line_number
           @src.pos += @src.matched_size
-          el = new_block_el(:codeblock, @src[4])
+          el = new_block_el(:codeblock, @src[4], nil, :location => start_line_number)
           lang = @src[3].to_s.strip
           el.attr['class'] = "language-#{lang}" unless lang.empty?
           @tree.children << el

--- a/lib/kramdown/parser/kramdown/codespan.rb
+++ b/lib/kramdown/parser/kramdown/codespan.rb
@@ -15,6 +15,7 @@ module Kramdown
 
       # Parse the codespan at the current scanner location.
       def parse_codespan
+        start_line_number = @src.current_line_number
         result = @src.scan(CODESPAN_DELIMITER)
         simple = (result.length == 1)
         reset_pos = @src.pos
@@ -30,7 +31,7 @@ module Kramdown
             text = text[1..-1] if text[0..0] == ' '
             text = text[0..-2] if text[-1..-1] == ' '
           end
-          @tree.children << Element.new(:codespan, text)
+          @tree.children << Element.new(:codespan, text, nil, :location => start_line_number)
         else
           @src.pos = reset_pos
           add_text(result)

--- a/lib/kramdown/parser/kramdown/emphasis.rb
+++ b/lib/kramdown/parser/kramdown/emphasis.rb
@@ -15,6 +15,7 @@ module Kramdown
 
       # Parse the emphasis at the current location.
       def parse_emphasis
+        start_line_number = @src.current_line_number
         result = @src.scan(EMPHASIS_START)
         element = (result.length == 2 ? :strong : :em)
         type = result[0..0]
@@ -27,7 +28,7 @@ module Kramdown
         end
 
         sub_parse = lambda do |delim, elem|
-          el = Element.new(elem)
+          el = Element.new(elem, nil, nil, :location => start_line_number)
           stop_re = /#{Regexp.escape(delim)}/
           found = parse_spans(el, stop_re) do
             (@src.pre_match[-1, 1] !~ /\s/) &&

--- a/lib/kramdown/parser/kramdown/extensions.rb
+++ b/lib/kramdown/parser/kramdown/extensions.rb
@@ -55,6 +55,7 @@ module Kramdown
       # or :span depending whether we parse a block or span extension tag.
       def parse_extension_start_tag(type)
         orig_pos = @src.pos
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
 
         error_block = lambda do |msg|
@@ -66,7 +67,7 @@ module Kramdown
 
         if @src[4] || @src.matched == '{:/}'
           name = (@src[4] ? "for '#{@src[4]}' " : '')
-          return error_block.call("Invalid extension stop tag #{name}found - ignoring it")
+          return error_block.call("Invalid extension stop tag #{name} found on line #{start_line_number} - ignoring it")
         end
 
         ext = @src[1]
@@ -80,12 +81,12 @@ module Kramdown
             body = result.sub!(stop_re, '')
             body.chomp! if type == :block
           else
-            return error_block.call("No stop tag for extension '#{ext}' found - ignoring it")
+            return error_block.call("No stop tag for extension '#{ext}' found on line #{start_line_number} - ignoring it")
           end
         end
 
         if !handle_extension(ext, opts, body, type)
-          error_block.call("Invalid extension with name '#{ext}' specified - ignoring it")
+          error_block.call("Invalid extension with name '#{ext}' specified on line #{start_line_number} - ignoring it")
         else
           true
         end

--- a/lib/kramdown/parser/kramdown/footnote.rb
+++ b/lib/kramdown/parser/kramdown/footnote.rb
@@ -19,13 +19,14 @@ module Kramdown
 
       # Parse the foot note definition at the current location.
       def parse_footnote_definition
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
 
-        el = Element.new(:footnote_def)
+        el = Element.new(:footnote_def, nil, nil, :location => start_line_number)
         parse_blocks(el, @src[2].gsub(INDENT, ''))
         warning("Duplicate footnote name '#{@src[1]}' - overwriting") if @footnotes[@src[1]]
         (@footnotes[@src[1]] = {})[:content] = el
-        @tree.children << Element.new(:eob, :footnote_def)
+        @tree.children << Element.new(:eob, :footnote_def, nil, :location => start_line_number)
         true
       end
       define_parser(:footnote_definition, FOOTNOTE_DEFINITION_START)
@@ -35,15 +36,16 @@ module Kramdown
 
       # Parse the footnote marker at the current location.
       def parse_footnote_marker
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
         fn_def = @footnotes[@src[1]]
         if fn_def
           fn_def[:marker] ||= []
-          fn_def[:marker].push(Element.new(:footnote, fn_def[:content], nil, :name => @src[1]))
+          fn_def[:marker].push(Element.new(:footnote, fn_def[:content], nil, :name => @src[1], :location => start_line_number))
           fn_def[:stack] = [@stack.map {|s| s.first}, @tree, fn_def[:marker]].flatten.compact
           @tree.children << fn_def[:marker].last
         else
-          warning("Footnote definition for '#{@src[1]}' not found")
+          warning("Footnote definition for '#{@src[1]}' not found on line #{start_line_number}")
           add_text(@src.matched)
         end
       end

--- a/lib/kramdown/parser/kramdown/header.rb
+++ b/lib/kramdown/parser/kramdown/header.rb
@@ -20,10 +20,11 @@ module Kramdown
       def parse_setext_header
         return false if !after_block_boundary?
 
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
         text, id, level = @src[1], @src[2], @src[3]
         text.strip!
-        el = new_block_el(:header, nil, nil, :level => (level == '-' ? 2 : 1), :raw_text => text)
+        el = new_block_el(:header, nil, nil, :level => (level == '-' ? 2 : 1), :raw_text => text, :location => start_line_number)
         add_text(text, el)
         el.attr['id'] = id if id
         @tree.children << el
@@ -39,12 +40,13 @@ module Kramdown
       def parse_atx_header
         return false if !after_block_boundary?
 
+        start_line_number = @src.current_line_number
         @src.check(ATX_HEADER_MATCH)
         level, text, id = @src[1], @src[2].to_s.strip, @src[3]
         return false if text.empty?
 
         @src.pos += @src.matched_size
-        el = new_block_el(:header, nil, nil, :level => level.length, :raw_text => text)
+        el = new_block_el(:header, nil, nil, :level => level.length, :raw_text => text, :location => start_line_number)
         add_text(text, el)
         el.attr['id'] = id if id
         @tree.children << el

--- a/lib/kramdown/parser/kramdown/horizontal_rule.rb
+++ b/lib/kramdown/parser/kramdown/horizontal_rule.rb
@@ -15,8 +15,9 @@ module Kramdown
 
       # Parse the horizontal rule at the current location.
       def parse_horizontal_rule
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
-        @tree.children << new_block_el(:hr)
+        @tree.children << new_block_el(:hr, nil, nil, :location => start_line_number)
         true
       end
       define_parser(:horizontal_rule, HR_START)

--- a/lib/kramdown/parser/kramdown/html_entity.rb
+++ b/lib/kramdown/parser/kramdown/html_entity.rb
@@ -15,12 +15,14 @@ module Kramdown
 
       # Parse the HTML entity at the current location.
       def parse_html_entity
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
         begin
           @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity(@src[1] || (@src[2] && @src[2].to_i) || @src[3].hex),
-                                        nil, :original => @src.matched)
+                                        nil, :original => @src.matched, :location => start_line_number)
         rescue ::Kramdown::Error
-          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('amp'))
+          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('amp'),
+                                        nil, :location => start_line_number)
           add_text(@src.matched[1..-1])
         end
       end

--- a/lib/kramdown/parser/kramdown/link.rb
+++ b/lib/kramdown/parser/kramdown/link.rb
@@ -22,7 +22,7 @@ module Kramdown
       def parse_link_definition
         @src.pos += @src.matched_size
         link_id, link_url, link_title = normalize_link_id(@src[1]), @src[2] || @src[3], @src[5]
-        warning("Duplicate link ID '#{link_id}' - overwriting") if @link_defs[link_id]
+        warning("Duplicate link ID '#{link_id}' on line #{@src.current_line_number} - overwriting") if @link_defs[link_id]
         @link_defs[link_id] = [link_url, link_title]
         @tree.children << Element.new(:eob, :link_def)
         true
@@ -53,6 +53,7 @@ module Kramdown
       # Parse the link at the current scanner position. This method is used to parse normal links as
       # well as image links.
       def parse_link
+        start_line_number = @src.current_line_number
         result = @src.scan(LINK_START)
         reset_pos = @src.pos
 
@@ -63,7 +64,7 @@ module Kramdown
           add_text(result)
           return
         end
-        el = Element.new(link_type)
+        el = Element.new(link_type, nil, nil, :location => start_line_number)
 
         count = 1
         found = parse_spans(el, LINK_BRACKET_STOP_RE) do

--- a/lib/kramdown/parser/kramdown/math.rb
+++ b/lib/kramdown/parser/kramdown/math.rb
@@ -17,6 +17,7 @@ module Kramdown
 
       # Parse the math block at the current location.
       def parse_block_math
+        start_line_number = @src.current_line_number
         if !after_block_boundary?
           return false
         elsif @src[1]
@@ -28,7 +29,7 @@ module Kramdown
         @src.pos += @src.matched_size
         data = @src[2]
         if before_block_boundary?
-          @tree.children << new_block_el(:math, data, nil, :category => :block)
+          @tree.children << new_block_el(:math, data, nil, :category => :block, :location => start_line_number)
           true
         else
           @src.pos = orig_pos
@@ -42,8 +43,9 @@ module Kramdown
 
       # Parse the inline math at the current location.
       def parse_inline_math
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
-        @tree.children << Element.new(:math, @src[1], nil, :category => :span)
+        @tree.children << Element.new(:math, @src[1], nil, :category => :span, :location => start_line_number)
       end
       define_parser(:inline_math, INLINE_MATH_START, '\$')
 

--- a/lib/kramdown/parser/kramdown/paragraph.rb
+++ b/lib/kramdown/parser/kramdown/paragraph.rb
@@ -29,6 +29,7 @@ module Kramdown
 
       # Parse the paragraph at the current location.
       def parse_paragraph
+        start_line_number = @src.current_line_number
         result = @src.scan(PARAGRAPH_MATCH)
         while !@src.match?(self.class::PARAGRAPH_END)
           result << @src.scan(PARAGRAPH_MATCH)
@@ -37,7 +38,7 @@ module Kramdown
         if @tree.children.last && @tree.children.last.type == :p
           @tree.children.last.children.first.value << "\n" << result
         else
-          @tree.children << new_block_el(:p)
+          @tree.children << new_block_el(:p, nil, nil, :location => start_line_number)
           result.lstrip!
           @tree.children.last.children << Element.new(@text_type, result)
         end

--- a/lib/kramdown/parser/kramdown/table.rb
+++ b/lib/kramdown/parser/kramdown/table.rb
@@ -26,7 +26,7 @@ module Kramdown
         return false if !after_block_boundary?
 
         orig_pos = @src.pos
-        table = new_block_el(:table, nil, nil, :alignment => [])
+        table = new_block_el(:table, nil, nil, :alignment => [], :location => @src.current_line_number)
         leading_pipe = (@src.check(TABLE_LINE) =~ /^\s*\|/)
         @src.scan(TABLE_SEP_LINE)
 
@@ -66,7 +66,9 @@ module Kramdown
               if i % 2 == 1
                 (cells.empty? ? cells : cells.last) << str
               else
-                reset_env(:src => StringScanner.new(str))
+                l_src = StringScannerKramdown.new(str)
+                l_src.start_line_number = @src.current_line_number
+                reset_env(:src => l_src)
                 root = Element.new(:root)
                 parse_spans(root, nil, [:codespan])
 
@@ -110,7 +112,9 @@ module Kramdown
 
         # Parse all lines of the table with the code span parser
         env = save_env
-        reset_env(:src => StringScanner.new(extract_string(orig_pos...(@src.pos-1), @src)))
+        l_src = StringScannerKramdown.new(extract_string(orig_pos...(@src.pos-1), @src))
+        l_src.start_line_number = @src.current_line_number
+        reset_env(:src => l_src)
         root = Element.new(:root)
         parse_spans(root, nil, [:codespan])
         restore_env(env)

--- a/lib/kramdown/parser/kramdown/typographic_symbol.rb
+++ b/lib/kramdown/parser/kramdown/typographic_symbol.rb
@@ -20,16 +20,21 @@ module Kramdown
 
       # Parse the typographic symbols at the current location.
       def parse_typographic_syms
+        start_line_number = @src.current_line_number
         @src.pos += @src.matched_size
         val = TYPOGRAPHIC_SYMS_SUBST[@src.matched]
         if val.kind_of?(Symbol)
-          @tree.children << Element.new(:typographic_sym, val)
+          @tree.children << Element.new(:typographic_sym, val, nil, :location => start_line_number)
         elsif @src.matched == '\\<<'
-          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('lt'))
-          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('lt'))
+          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('lt'),
+                                        nil, :location => start_line_number)
+          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('lt'),
+                                        nil, :location => start_line_number)
         else
-          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('gt'))
-          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('gt'))
+          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('gt'),
+                                        nil, :location => start_line_number)
+          @tree.children << Element.new(:entity, ::Kramdown::Utils::Entities.entity('gt'),
+                                        nil, :location => start_line_number)
         end
       end
       define_parser(:typographic_syms, TYPOGRAPHIC_SYMS_RE, '--|\\.\\.\\.|(?:\\\\| )?(?:<<|>>)')

--- a/lib/kramdown/string_scanner_kramdown.rb
+++ b/lib/kramdown/string_scanner_kramdown.rb
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+# This patched StringScanner adds line number information for current scan
+# position and a start_line_number override for nested StringScanners.
+require 'strscan'
+class StringScannerKramdown < StringScanner
+
+  # Set start_line_number to handle nested StringScanners that scan a sub-string
+  # of the source document. Kramdown uses this e.g., for span level parsers.
+  attr_accessor :start_line_number
+
+  # To make this unicode (multibyte) aware, we have to use charpos which was
+  # added in Ruby version 2.0.0.
+  # This method will work with older versions of Ruby, however it will report
+  # incorrect line numbers if the scanned string contains multibyte characters.
+  if instance_methods.include?(:charpos)
+    def best_pos
+      charpos
+    end
+  else
+    def best_pos
+      pos
+    end
+  end
+
+  # Returns the line number for current charpos.
+  # NOTE: Requires that all line endings are normalized to '\n'
+  # NOTE: Normally we'd have to add one to the count of newlines to get the
+  # correct line number. However we add the one indirectly by using a one-based
+  # start_line_number.
+  def current_line_number
+    string[0..best_pos].count("\n") + (start_line_number || 1)
+  end
+
+end

--- a/test/test_location.rb
+++ b/test/test_location.rb
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+
+require 'minitest/autorun'
+require 'kramdown'
+
+Encoding.default_external = 'utf-8' if RUBY_VERSION >= '1.9'
+
+describe 'location' do
+
+  # checks that +element+'s :location option corresponds to the location stored
+  # in the element.attr['class']
+  def check_element_for_location(element)
+    if (match = /^line-(\d+)/.match(element.attr['class'] || ''))
+      expected_line = match[1].to_i
+      element.options[:location].must_equal(expected_line)
+    end
+    element.children.each do |child|
+      check_element_for_location(child)
+    end
+  end
+
+  # Test cases consist of a kramdown string that uses IALs to specify the expected
+  # line numbers for a given element.
+  test_cases = {
+    'autolink' => %(testing autolinks\n\n<http://kramdown.org>{:.line-3}),
+    'blockquote' => %(
+      > block quote1
+      >
+      > * {:.line-3} list item in block quote
+      > * {:.line-4} list item in block quote
+      > {:.line-3}
+      {:.line-1}
+
+      > block quote2
+      > {:.line-8}
+    ),
+    'codeblock' => %(\na para\n\n~~~~\ntest code 1\n~~~~\n{:.line-3}\n\n    test code 2\n{:.line-8}\n),
+    'codespan' => %(a para\n\nanother para `<code>`{:.line-3} with code\n),
+    'emphasis' => %(
+      para *span*{:.line-1}
+      {:.line-1}
+
+      ## header *span*{:.line-4}
+      {:.line-4}
+
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      cillum *short span on single line*{:.line-11}
+      dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+      *long span over multiple lines - proident, sunt in culpa qui officia deserunt
+      mollit anim id est laborum.*{:.line-13}
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      `code span`{:.line-18}
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      {:.line-7}
+    ),
+    'header' => %(
+      # header1
+      {:.line-1}
+
+      ## header2
+      {:.line-4}
+
+      ## header3
+      {:.line-7}
+
+      header4
+      =======
+      {:.line-10}
+
+      header5
+      -------
+      {:.line-14}
+    ),
+    'horizontal_rule' => %(\na para\n\n----\n{:.line-3}\n),
+    'html_entity' => "a para\n\nanother para with &amp;{:.line-3} html entity.\n",
+    'link' => %(
+      a para
+
+      This is [a link](http://rubyforge.org){:.line-3} to a page.
+
+      Here comes a ![smiley](../images/smiley.png){:.line-5}
+    ),
+    'list' => %(
+      * {:.line-1} list item
+      * {:.line-2} list item
+      * {:.line-3} list item
+      {:.line-1}
+
+      {:.line-7}
+      1. {:.line-7} list item
+      2. {:.line-8} list item
+      3. {:.line-9} list item
+
+      {:.line-12}
+      definition term 1
+      : {:.line-13} definition definition 1
+      definition term 2
+      : {:.line-15} definition definition 2
+    ),
+    'math_block' => %(\na para\n\n$$5+5$$\n{:.line-3}\n),
+    'math_inline' => %(\na para\n\nanother para with inline math $$5+5$${:.line-3}\n),
+    'paragraph' => %(
+      para1
+      {:.line-1}
+
+      para2
+      {:.line-4}
+
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+      {:.line-7}
+
+      {:.line-14}
+      para with leading IAL
+    ),
+    'table' => %(
+      a para
+
+      |first|second|third|
+      |-----|------|-----|
+      |a    |b     |c    |
+      {:.line-3}
+    ),
+    'typographic_symbol' => %(
+      a para
+
+      another para ---{:.line-3}
+
+      another para ...{:.line-5}
+    )
+  }
+  test_cases.each do |name, test_string|
+    it "Handles #{ name }" do
+      doc = Kramdown::Document.new(test_string.gsub(/^      /, '').strip)
+      check_element_for_location(doc.root)
+    end
+  end
+
+  it 'adds location info to duplicate abbreviation definition warnings' do
+    test_string = %(This snippet contains a duplicate abbreviation definition
+
+*[duplicate]: The first definition
+*[duplicate]: The second definition
+    )
+    doc = Kramdown::Document.new(test_string.strip)
+    doc.warnings.must_equal ["Duplicate abbreviation ID 'duplicate' on line 4 - overwriting"]
+  end
+
+end

--- a/test/test_string_scanner_kramdown.rb
+++ b/test/test_string_scanner_kramdown.rb
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+require 'minitest/autorun'
+require 'kramdown/string_scanner_kramdown'
+
+describe StringScannerKramdown do
+
+  [
+    ["...........X............", [/X/], 1],
+    ["1\n2\n3\n4\n5\n6X", [/X/], 6],
+    ["1\n2\n3\n4\n5\n6X\n7\n8X", [/X/,/X/], 8],
+    [(".\n" * 1000) + 'X', [/X/], 1001]
+  ].each_with_index do |test_data, i|
+    test_string, scan_regexes, expect = test_data
+    it "computes the correct current_line_number for example ##{i+1}" do
+      str_sc = StringScannerKramdown.new(test_string)
+      scan_regexes.each { |scan_re| str_sc.scan_until(scan_re) }
+      str_sc.current_line_number.must_equal expect
+    end
+  end
+
+
+end


### PR DESCRIPTION
- Uses StringScannerKramdown (which has current_line_number method) instead of StringScanner.
- Records :location option on all Kramdown::Elements where this makes sense and where it is easily implemented.
- Initializes nested StringScanners with their parent Element's :location as start_line_number.
- Adds tests for :location information.
- Adds tests for StringScannerKramdown.

See pull request for more details.
