### PR TITLE
Return :default when there's no alignment in the style.

### DIFF
--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -420,7 +420,7 @@ module Kramdown
                 if td.attr['style']
                   td.attr['style'].slice!(/(?:;\s*)?text-align:\s+(center|left|right)/)
                   td.attr.delete('style') if td.attr['style'].strip.empty?
-                  $1.to_sym
+                  $1.try(:to_sym) || :default
                 else
                   :default
                 end


### PR DESCRIPTION
There was an error when parsing a <td> tag with style but without "text-align: zzzzzz" string in it. The changes was to check for nil and return :default if this is the case.
