### PR TITLE
Add charset attribute name to document.html

### DIFF
--- a/data/kramdown/document.html
+++ b/data/kramdown/document.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <% if @converter.root.options[:encoding] %>
-    <meta http-equiv="Content-type" content="text/html;<%= @converter.root.options[:encoding] %>">
+    <meta http-equiv="Content-type" content="text/html;charset=<%= @converter.root.options[:encoding] %>">
     <% end %>
 <%
 extend ::Kramdown::Utils::Html


### PR DESCRIPTION
The proposed change will add the charset attribute key "charset=" before its value, fixing an issue where some symbols do not display properly in certain browsers.
