### PR TITLE
Add link to GFM Parser doc page

### DIFF
--- a/doc/documentation.template
+++ b/doc/documentation.template
@@ -4,6 +4,7 @@
 * Parsers
   * [kramdown](parser/kramdown.html)
   * [Markdown](parser/markdown.html)
+  * [GFM](parser/gfm.html)
   * [HTML](parser/html.html)
 * Converters
   * [HTML](converter/html.html)


### PR DESCRIPTION
in `doc/documentation.template`
