### PR TITLE
fixed footnote display for footnotes in footnotes

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -280,6 +280,13 @@ module Kramdown
           @footnote_counter += 1
           @footnotes << [el.options[:name], el.value, number, 0]
           @footnotes_by_name[el.options[:name]] = @footnotes.last
+
+          # parse the footnote content to find any embedded footnotes,
+          # but don't add the parsed content to the actual rendered HTML
+          ignore = ''
+          el.value.children.each do |inner_el|
+            ignore << send(DISPATCHER[inner_el.type], inner_el, indent)
+          end
         end
         "<sup id=\"fnref:#{el.options[:name]}#{repeat}\"><a href=\"#fn:#{el.options[:name]}\" class=\"footnote\">#{number}</a></sup>"
       end


### PR DESCRIPTION
_[ insert Yo, Dawg joke here ]_

This fixes issue #161, where footnote content is not being displayed for footnotes within footnotes. It's making the converter do extra work, since it has to convert the footnote content once to make sure any embedded footnotes get tracked, and a second time when creating the block of footnotes, but (a) footnotes are usually pretty small and (b) I didn't know how else to capture the footnotes.
