### PR TITLE
Allow HTML indent value to be configurable

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -52,7 +52,7 @@ module Kramdown
         @footnote_location = nil
         @toc = []
         @toc_code = nil
-        @indent = 2
+        @indent = @options[:indent] || 2
         @stack = []
         @coderay_enabled = @options[:enable_coderay] && HIGHLIGHTING_AVAILABLE
       end


### PR DESCRIPTION
kramdown currently defaults to 2 spaces for indenting HTML. This change allows this value to be configurable, using the `indent` option.

I welcome your feedback on this PR.
