### PR TITLE
Added strikethrough syntax to GitHub Flavored Markdown parser

### DIFF
--- a/doc/parser/gfm.page
+++ b/doc/parser/gfm.page
@@ -14,7 +14,8 @@ sites, for example StackOverflow.
 ## Conformance
 
 At the moment this parser is identical to the kramdown parser, except that it adds support for
-fenced code blocks using three or more backticks and enforces hard line breaks in paragraphs.
+fenced code blocks using three or more backticks, strikethroughs using two or more tildes and enforces
+hard line breaks in paragraphs.
 
 ## Options
 

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -14,6 +14,11 @@ module Kramdown
           i = @block_parsers.index(current)
           @block_parsers.delete(current)
           @block_parsers.insert(i, replacement)
+
+          i = @span_parsers.index(:escaped_chars)
+          @span_parsers[i] = :escaped_chars_gfm if i
+
+          @span_parsers << :strikethrough_gfm
         end
       end
 
@@ -28,11 +33,11 @@ module Kramdown
             children = []
             lines = child.value.split(/\n/, -1)
             omit_trailing_br = (Kramdown::Element.category(element) == :block && element.children[-1] == child &&
-                                lines[-1].empty?)
+                lines[-1].empty?)
             lines.each_with_index do |line, index|
               children << Element.new(:text, (index > 0 ? "\n#{line}" : line))
               children << Element.new(:br) if index < lines.size - 2 ||
-                (index == lines.size - 2 && !omit_trailing_br)
+                  (index == lines.size - 2 && !omit_trailing_br)
             end
             children
           elsif child.type == :html_element
@@ -50,6 +55,30 @@ module Kramdown
       FENCED_CODEBLOCK_MATCH = /^(([~`]){3,})\s*?(\w+)?\s*?\n(.*?)^\1\2*\s*?\n/m
       define_parser(:codeblock_fenced_gfm, /^[~`]{3,}/, nil, 'parse_codeblock_fenced')
 
+      STRIKETHROUGH_DELIM = /~{2,}/
+      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}[^~]+#{STRIKETHROUGH_DELIM}/
+      define_parser(:strikethrough_gfm, STRIKETHROUGH_MATCH, nil)
+
+      def parse_strikethrough_gfm
+        line_number = @src.current_line_number
+
+        if @src.scan(STRIKETHROUGH_DELIM)
+          el = Element.new(:html_element, 'del', {}, category: :span, line: line_number)
+          @tree.children << el
+          parse_spans(el, STRIKETHROUGH_DELIM)
+          @src.scan(STRIKETHROUGH_DELIM)
+        end
+      end
+
+      ESCAPED_CHARS_GFM = /\\([\\.*_+`<>()\[\]{}#!:\|"'\$=\-~])/
+
+      # Parse the backslash-escaped character at the current location.
+      def parse_escaped_chars_gfm
+        @src.pos += @src.matched_size
+        add_text(@src[1])
+      end
+
+      define_parser(:escaped_chars_gfm, ESCAPED_CHARS_GFM, '\\\\')
     end
   end
 end

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -63,7 +63,7 @@ module Kramdown
         line_number = @src.current_line_number
 
         if @src.scan(STRIKETHROUGH_DELIM)
-          el = Element.new(:html_element, 'del', {}, category: :span, line: line_number)
+          el = Element.new(:html_element, 'del', {}, :category => :span, :line => line_number)
           @tree.children << el
           parse_spans(el, STRIKETHROUGH_DELIM)
           @src.scan(STRIKETHROUGH_DELIM)

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -56,8 +56,8 @@ module Kramdown
       define_parser(:codeblock_fenced_gfm, /^[~`]{3,}/, nil, 'parse_codeblock_fenced')
 
       STRIKETHROUGH_DELIM = /~{2,}/
-      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}[^~]+#{STRIKETHROUGH_DELIM}/
-      define_parser(:strikethrough_gfm, STRIKETHROUGH_MATCH, nil)
+      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}.+#{STRIKETHROUGH_DELIM}/m
+      define_parser(:strikethrough_gfm, STRIKETHROUGH_MATCH, '~~')
 
       def parse_strikethrough_gfm
         line_number = @src.current_line_number

--- a/test/testcases_gfm/strikethrough.html
+++ b/test/testcases_gfm/strikethrough.html
@@ -4,10 +4,6 @@
 
 <p><del>This is yet another test</del></p>
 
-<pre><code class="language-Ruby">m = 'This is a fenced codeblock'
-# Another line in the fenced codeblock
-</code></pre>
-
 <p><del>
 This
 is
@@ -21,3 +17,5 @@ test
 <p>This is a ~~broken strikethrough~; it’s not closed correctly.</p>
 
 <p>This is an ~~escaped~~ strikethrough.</p>
+
+<p>This is a <del>strikethrough with a ~ in the middle</del></p>

--- a/test/testcases_gfm/strikethrough.html
+++ b/test/testcases_gfm/strikethrough.html
@@ -14,8 +14,6 @@ test
 
 <p>This is an <del><em>inline</em> <strong>strikethrough</strong></del> test</p>
 
-<p>This is a ~~broken strikethrough~; it’s not closed correctly.</p>
-
 <p>This is an ~~escaped~~ strikethrough.</p>
 
 <p>This is a <del>strikethrough with a ~ in the middle</del></p>

--- a/test/testcases_gfm/strikethrough.html
+++ b/test/testcases_gfm/strikethrough.html
@@ -1,0 +1,23 @@
+<p><del>This is a test</del></p>
+
+<p><del>This is another test</del></p>
+
+<p><del>This is yet another test</del></p>
+
+<pre><code class="language-Ruby">m = 'This is a fenced codeblock'
+# Another line in the fenced codeblock
+</code></pre>
+
+<p><del>
+This
+is
+a
+<strong>multiline</strong>
+test
+</del></p>
+
+<p>This is an <del><em>inline</em> <strong>strikethrough</strong></del> test</p>
+
+<p>This is a ~~broken strikethrough~; it’s not closed correctly.</p>
+
+<p>This is an ~~escaped~~ strikethrough.</p>

--- a/test/testcases_gfm/strikethrough.options
+++ b/test/testcases_gfm/strikethrough.options
@@ -1,0 +1,1 @@
+:input: 'GFM'

--- a/test/testcases_gfm/strikethrough.text
+++ b/test/testcases_gfm/strikethrough.text
@@ -14,8 +14,6 @@ test
 
 This is an ~~_inline_ **strikethrough**~~ test
 
-This is a ~~broken strikethrough~; it's not closed correctly.
-
 This is an \~~escaped~~ strikethrough.
 
 This is a ~~strikethrough with a ~ in the middle~~

--- a/test/testcases_gfm/strikethrough.text
+++ b/test/testcases_gfm/strikethrough.text
@@ -4,11 +4,6 @@
 
 ~~This is yet another test~~~
 
-~~~ Ruby
-m = 'This is a fenced codeblock'
-# Another line in the fenced codeblock
-~~~
-
 ~~
 This
 is
@@ -22,3 +17,5 @@ This is an ~~_inline_ **strikethrough**~~ test
 This is a ~~broken strikethrough~; it's not closed correctly.
 
 This is an \~~escaped~~ strikethrough.
+
+This is a ~~strikethrough with a ~ in the middle~~

--- a/test/testcases_gfm/strikethrough.text
+++ b/test/testcases_gfm/strikethrough.text
@@ -1,0 +1,24 @@
+~~This is a test~~
+
+~~~This is another test~~~
+
+~~This is yet another test~~~
+
+~~~ Ruby
+m = 'This is a fenced codeblock'
+# Another line in the fenced codeblock
+~~~
+
+~~
+This
+is
+a
+**multiline**
+test
+~~
+
+This is an ~~_inline_ **strikethrough**~~ test
+
+This is a ~~broken strikethrough~; it's not closed correctly.
+
+This is an \~~escaped~~ strikethrough.


### PR DESCRIPTION
GitHub Flavored Markdown supports strikethrough text according to [GitHub Help - GitHub Flavored Markdown](https://help.github.com/articles/github-flavored-markdown/) but the GFM parser included with kramdown doesn't support it.

I've added strikethrough support to the GFM parser: when it encounters text delimited by two or more tildes, it creates a &lt;del&gt; HTML element that contains the text. This doesn't affect the standard kramdown parser.