### PR TITLE
Allow image to convert without an alt attribute

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -286,7 +286,7 @@ module Kramdown
       end
 
       def convert_img(el, opts)
-        alt_text = el.attr['alt'].gsub(ESCAPED_CHAR_RE) { $1 ? "\\#{$1}" : $2 }
+        alt_text = el.attr['alt'].blank? ? "" : el.attr['alt'].gsub(ESCAPED_CHAR_RE) { $1 ? "\\#{$1}" : $2 }
         if el.attr['src'].empty?
           "![#{alt_text}]()"
         else


### PR DESCRIPTION
Added a potential fix for a NoMethodError 'gsub' for nil when trying to convert images with no alt text attribute. Issue referenced here: https://github.com/gettalong/kramdown/issues/198
