### PR TITLE
Ignore empty title attributes

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -280,7 +280,7 @@ module Kramdown
                   end
           "[#{inner(el, opts)}][#{index}]"
         else
-          title = el.attr['title'].to_s.empty? ? '' : ' "' + el.attr['title'].gsub(/"/, "&quot;") + '"'
+          title = parse_title(el.attr['title'])
           "[#{inner(el, opts)}](#{el.attr['href']}#{title})"
         end
       end
@@ -290,7 +290,7 @@ module Kramdown
         if el.attr['src'].empty?
           "![#{alt_text}]()"
         else
-          title = (el.attr['title'] ? ' "' + el.attr['title'].gsub(/"/, "&quot;") + '"' : '')
+          title = parse_title(el.attr['title'])
           link = if el.attr['src'].count("()") > 0
                    "<#{el.attr['src']}>"
                  else
@@ -369,8 +369,8 @@ module Kramdown
         res = ''
         res << "\n\n" if @linkrefs.size > 0
         @linkrefs.each_with_index do |el, i|
-          title = el.attr['title']
-          res << "[#{i+1}]: #{el.attr['href']}#{title ? ' "' + title.gsub(/"/, "&quot;") + '"' : ''}\n"
+          title = parse_title(el.attr['title'])
+          res << "[#{i+1}]: #{el.attr['href']}#{title}\n"
         end
         res
       end
@@ -413,6 +413,10 @@ module Kramdown
         res = "footnotes" << (res.strip.empty? ? '' : " #{res}") if (el.type == :ul || el.type == :ol) &&
           (el.options[:ial][:refs].include?('footnotes') rescue nil)
         res.strip.empty? ? nil : "{:#{res}}"
+      end
+
+      def parse_title(attr)
+        attr.to_s.empty? ? '' : ' "' + attr.gsub(/"/, '&quot;') + '"'
       end
 
       # :startdoc:

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -107,6 +107,7 @@ class TestFiles < Minitest::Test
   else
     EXCLUDE_LATEX_FILES = ['test/testcases/span/01_link/image_in_a.text', # bc of image link
                            'test/testcases/span/01_link/imagelinks.text', # bc of image links
+                           'test/testcases/span/01_link/empty_title.text',
                            'test/testcases/span/04_footnote/markers.text', # bc of footnote in header
                           ].compact
     Dir[File.dirname(__FILE__) + '/testcases/**/*.text'].each do |text_file|

--- a/test/testcases/span/01_link/empty_title.htmlinput
+++ b/test/testcases/span/01_link/empty_title.htmlinput
@@ -1,0 +1,3 @@
+<p>Image with empty title: <img src="/images/other.png" alt="alt text" title="" /></p>
+
+<p>Link <a href="http://example.tld" title="">reference</a> with empty title.</p>

--- a/test/testcases/span/01_link/empty_title.text
+++ b/test/testcases/span/01_link/empty_title.text
@@ -1,4 +1,7 @@
 Image with empty title: ![alt text](/images/other.png)
 
-[reference]: http://example.tld
-Link [reference] with empty title.
+Link [reference][1] with empty title.
+
+
+
+[1]: http://example.tld

--- a/test/testcases/span/01_link/empty_title.text
+++ b/test/testcases/span/01_link/empty_title.text
@@ -1,0 +1,4 @@
+Image with empty title: ![alt text](/images/other.png)
+
+[reference]: http://example.tld
+Link [reference] with empty title.


### PR DESCRIPTION
Fixes #199.

The fix is not complete though as some tests still fail. This is because conversion is not reversible for empty title attributes:
```
$ kramdown -ihtml -okramdown <<< '<p><img src="a" alt="b" title="" /></p>'
![b](a)
```
but
```
$ kramdown -ikramdown -ohtml <<< '![b](a)'
<p><img src="a" alt="b" /></p>
```
and therefore `assert_equal` fails.

Any suggestions? Should I avoid these tests?