### PR TITLE
Add pygments syntax highlighter.

### DIFF
--- a/lib/kramdown/converter.rb
+++ b/lib/kramdown/converter.rb
@@ -31,7 +31,7 @@ module Kramdown
 
     configurable(:syntax_highlighter)
 
-    ["Coderay", "Rouge"].each do |klass_name|
+    ["Coderay", "Rouge", "Pygments"].each do |klass_name|
       kn_down = klass_name.downcase.intern
       add_syntax_highlighter(kn_down) do |converter, text, lang, type, opts|
         require "kramdown/converter/syntax_highlighter/#{kn_down}"

--- a/lib/kramdown/converter/syntax_highlighter/pygments.rb
+++ b/lib/kramdown/converter/syntax_highlighter/pygments.rb
@@ -1,0 +1,37 @@
+require 'rexml/parsers/baseparser'
+
+module Kramdown::Converter::SyntaxHighlighter
+  module Pygments
+    begin
+      require 'pygments'
+
+      # Highlighting via pygments is available if this constant is +true+.
+      AVAILABLE = true
+    rescue LoadError
+      AVAILABLE = false  # :nodoc:
+    end
+
+    extend ::Kramdown::Utils::Html
+
+    DEFAULTS = {
+      :startinline => true,
+      :encoding => 'utf-8',
+      :nowrap => true
+    }.freeze
+
+    def self.call(converter, text, lang, type, _unused_opts)
+      opts = DEFAULTS.merge(converter.options[:syntax_highlighter_opts])
+      lexer = lang || opts[:default_lang]
+      return nil unless lexer
+
+      code = ::Pygments.highlight(text, :lexer => lexer, :options => opts)
+
+      attrs = {
+        "class" => "language-#{lexer.gsub('+', '-')}",
+        "data-lang" => lexer
+      }
+
+      "<pre><code#{html_attributes(attrs)}>#{code.chomp}</code></pre>"
+    end
+  end
+end


### PR DESCRIPTION
Adds support for syntax highlighting with Pygments. It's an incredibly popular (if not the no. 1) code highlighter, so it seems Kramdown support would be a suitable addition =)

A few things are not quite fleshed out, thoughts would be :+1:

- [ ] I have not included the `<div highlight>` part because everything gets wrapped in another `<div class="highlighter-pygments">` tag. The outer tag feels wrong, are there historical reasons the outer div needs to be used? For drop-in compatibility with blogging platforms like Jekyll/Middleman, the structure needs to just have the `<div class="highlight">` wrapper.
- [ ] This file has to require the REXML stuff because it isn't req'd in the Utils file where it is referenced. Any issues moving the statement there?
- [ ] The HTML Utils helpers would make sense usable without mixing in, e.g. `::Kramdown::Utils::Html.html_attributes` with an `extend self`
- [ ] Needs specs. I'd appreciate direction/examples on where to start.