### PR TITLE
Enabled loading of external images

### DIFF
--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -149,14 +149,17 @@ module Kramdown
         elsif img.attr['src'] !~ /\.jpe?g$|\.png$/
           warning("Cannot render images other than JPEG or PNG, got #{img.attr['src']}#{line ? " on line #{line}" : ''}")
           return nil
-        end
-
-        img_dirs = (@options[:image_directories] || ['.']).dup
-        begin
-          img_path = File.join(img_dirs.shift, img.attr['src'])
-          image_obj, image_info = @pdf.build_image_object(open(img_path))
-        rescue
-          img_dirs.empty? ? raise : retry
+        elsif img.attr['src'] =~ /^[hH][tT][tT][pP][sS]?:/
+          warning("Loading external image: #{img.attr['src']}")
+          image_obj, image_info = @pdf.build_image_object(open(img.attr['src']))
+        else
+          img_dirs = (@options[:image_directories] || ['.']).dup
+          begin
+            img_path = File.join(img_dirs.shift, img.attr['src'])
+            image_obj, image_info = @pdf.build_image_object(open(img_path))
+          rescue
+            img_dirs.empty? ? raise : retry
+          end
         end
 
         options = {:position => :center}


### PR DESCRIPTION
I needed to transform some markdown files into PDF, and noticed that kramdown tries to load all images from local files at least when rendering the PDF. I'm no Ruby expert, but managed to hack together a trivial change where images starting with http(s) are loaded "as-is" from the external source. 

If you think it's good enough, please feel free to include it. And thanks for creating such a nice tool!