### PR TITLE
Fix fenced code blocks

### DIFF
--- a/lib/kramdown/parser/kramdown/codeblock.rb
+++ b/lib/kramdown/parser/kramdown/codeblock.rb
@@ -31,8 +31,8 @@ module Kramdown
       define_parser(:codeblock, CODEBLOCK_START)
 
 
-      FENCED_CODEBLOCK_START = /^~{3,}/
-      FENCED_CODEBLOCK_MATCH = /^((~){3,})\s*?(\w+)?\s*?\n(.*?)^\1\2*\s*?\n/m
+      FENCED_CODEBLOCK_START = /^[~`]{3,}/
+      FENCED_CODEBLOCK_MATCH = /^(([~`]){3,})\s*?(\w+)?\s*?\n(.*?)^\1\2*\s*?\n/m
 
       # Parse the fenced codeblock at the current location.
       def parse_codeblock_fenced
@@ -49,7 +49,6 @@ module Kramdown
         end
       end
       define_parser(:codeblock_fenced, FENCED_CODEBLOCK_START)
-
     end
   end
 end


### PR DESCRIPTION
Triple backtick with language wasn't working, this fixes it e.g.:


     ```ruby
     def blah
     end
     ```

wasn't working, but:

     ~~~ruby
     def blah
     end
     ~~~

was working fine - a regex issue.