### PR TITLE
Prevent conversion to Emoji on iOS

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -443,9 +443,9 @@ module Kramdown
             insert_space = false
           end
 
-          para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [insert_space ? ' ' : '', name, "&#8617;"])
+          para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [insert_space ? ' ' : '', name, "&#8617;&#xfe0e;"])
           (1..repeat).each do |index|
-            para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [" ", "#{name}:#{index}", "&#8617;<sup>#{index+1}</sup>"])
+            para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [" ", "#{name}:#{index}", "&#8617;&#xfe0e;<sup>#{index+1}</sup>"])
           end
 
           ol.children << Element.new(:raw, convert(li, 4))


### PR DESCRIPTION
Appending `&#xfe0e;` to the Unicode-represenation of the reversed arrow will prevent the conversion to an Emoji graphic on iOS. Take a look at this issue for better understanding: https://github.com/jekyll/jekyll/issues/3751