### PR TITLE
Prevent conversion to Emoji on iOS

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -443,9 +443,9 @@ module Kramdown
             insert_space = false
           end
 
-          para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [insert_space ? ' ' : '', name, "&#8617;"])
+          para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [insert_space ? ' ' : '', name, "&#8617;&#xfe0e;"])
           (1..repeat).each do |index|
-            para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [" ", "#{name}:#{index}", "&#8617;<sup>#{index+1}</sup>"])
+            para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [" ", "#{name}:#{index}", "&#8617;&#xfe0e;<sup>#{index+1}</sup>"])
           end
 
           ol.children << Element.new(:raw, convert(li, 4))

--- a/test/testcases/block/12_extension/options.html
+++ b/test/testcases/block/12_extension/options.html
@@ -15,7 +15,7 @@ some <span>*para*</span>
 <div class="footnotes">
   <ol start="10">
     <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/12_extension/options2.html
+++ b/test/testcases/block/12_extension/options2.html
@@ -4,7 +4,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/14_table/table_with_footnote.html
+++ b/test/testcases/block/14_table/table_with_footnote.html
@@ -19,7 +19,7 @@
       <blockquote>
         <p>special here</p>
       </blockquote>
-      <p><a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:1" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/16_toc/toc_with_footnotes.html
+++ b/test/testcases/block/16_toc/toc_with_footnotes.html
@@ -7,7 +7,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:1">
-      <p>Some footnote content here <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>Some footnote content here <a href="#fnref:1" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/footnote_nr.html
+++ b/test/testcases/span/04_footnote/footnote_nr.html
@@ -3,10 +3,10 @@
 <div class="footnotes">
   <ol start="35">
     <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
     <li id="fn:bc">
-      <p>Some other text. <a href="#fnref:bc" class="reversefootnote">&#8617;</a></p>
+      <p>Some other text. <a href="#fnref:bc" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/inside_footnote.html
+++ b/test/testcases/span/04_footnote/inside_footnote.html
@@ -5,13 +5,13 @@
 <div class="footnotes">
   <ol>
     <li id="fn:first">
-      <p>Consecutur adisping.<sup id="fnref:third"><a href="#fn:third" class="footnote">3</a></sup> <a href="#fnref:first" class="reversefootnote">&#8617;</a></p>
+      <p>Consecutur adisping.<sup id="fnref:third"><a href="#fn:third" class="footnote">3</a></sup> <a href="#fnref:first" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
     <li id="fn:second">
-      <p>Sed ut perspiciatis unde omnis. <a href="#fnref:second" class="reversefootnote">&#8617;</a></p>
+      <p>Sed ut perspiciatis unde omnis. <a href="#fnref:second" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
     <li id="fn:third">
-      <p>Sed ut. <a href="#fnref:third" class="reversefootnote">&#8617;</a></p>
+      <p>Sed ut. <a href="#fnref:third" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/markers.html
+++ b/test/testcases/span/04_footnote/markers.html
@@ -17,7 +17,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:fn">
-      <p>Some foot note text <a href="#fnref:fn" class="reversefootnote">&#8617;</a> <a href="#fnref:fn:1" class="reversefootnote">&#8617;<sup>2</sup></a> <a href="#fnref:fn:2" class="reversefootnote">&#8617;<sup>3</sup></a></p>
+      <p>Some foot note text <a href="#fnref:fn" class="reversefootnote">&#8617;&#xfe0e;</a> <a href="#fnref:fn:1" class="reversefootnote">&#8617;&#xfe0e;<sup>2</sup></a> <a href="#fnref:fn:2" class="reversefootnote">&#8617;&#xfe0e;<sup>3</sup></a></p>
     </li>
     <li id="fn:3">
       <p>other text
@@ -26,21 +26,21 @@ with more lines</p>
       <blockquote>
         <p>and a quote</p>
       </blockquote>
-      <p><a href="#fnref:3" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:3" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
     <li id="fn:1">
-      <p>some <em>text</em> <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>some <em>text</em> <a href="#fnref:1" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
     <li id="fn:now">
 
       <pre><code>code block
 continued here
 </code></pre>
-      <p><a href="#fnref:now" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:now" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
     <li id="fn:empty">
 
-      <p><a href="#fnref:empty" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:empty" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/placement.html
+++ b/test/testcases/span/04_footnote/placement.html
@@ -1,7 +1,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:1">
-      <p>Footnote \` text <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>Footnote \` text <a href="#fnref:1" class="reversefootnote">&#8617;&#xfe0e;</a></p>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
Appending `&#xfe0e;` to the Unicode-represenation of the reversed arrow will prevent the conversion to an Emoji graphic on iOS. Take a look at this issue for better understanding: https://github.com/jekyll/jekyll/issues/3751