### PR TITLE
Implements a JSON converter

### DIFF
--- a/lib/kramdown/converter.rb
+++ b/lib/kramdown/converter.rb
@@ -26,6 +26,7 @@ module Kramdown
     autoload :Toc, 'kramdown/converter/toc'
     autoload :RemoveHtmlTags, 'kramdown/converter/remove_html_tags'
     autoload :Pdf, 'kramdown/converter/pdf'
+    autoload :Json, 'kramdown/converter/json'
 
     extend ::Kramdown::Utils::Configurable
 

--- a/lib/kramdown/converter.rb
+++ b/lib/kramdown/converter.rb
@@ -26,7 +26,7 @@ module Kramdown
     autoload :Toc, 'kramdown/converter/toc'
     autoload :RemoveHtmlTags, 'kramdown/converter/remove_html_tags'
     autoload :Pdf, 'kramdown/converter/pdf'
-    autoload :Json, 'kramdown/converter/json'
+    autoload :Jsonx, 'kramdown/converter/jsonx'
 
     extend ::Kramdown::Utils::Configurable
 

--- a/lib/kramdown/converter/json.rb
+++ b/lib/kramdown/converter/json.rb
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+#
+#--
+# Copyright (C) 2009-2015 Thomas Leitner <t_leitner@gmx.at>
+#
+# This file is part of kramdown which is licensed under the MIT.
+#++
+#
+
+require 'kramdown/parser'
+require 'kramdown/converter'
+require 'kramdown/utils'
+require 'json'
+
+module Kramdown
+
+  module Converter
+
+    # Converts a Kramdown::Document to JSON.
+    #
+    class Json < Base
+
+      def convert(el)
+        tree = get_tree(el)
+        tree.to_json
+      end
+
+      def get_tree(el)
+        hash = {type: el.type}
+        hash[:attr] = el.attr unless el.attr.empty?
+        hash[:value] = el.value unless el.value.nil?
+        unless el.children.empty?
+          hash[:children] = []
+          el.children.each {|child| hash[:children] << get_tree(child)}
+        end
+        hash
+      end
+
+    end
+
+  end
+end

--- a/lib/kramdown/converter/jsonx.rb
+++ b/lib/kramdown/converter/jsonx.rb
@@ -18,11 +18,21 @@ module Kramdown
 
     # Converts a Kramdown::Document to JSON.
     #
-    class Json < Base
+    # I am calling the class "Jsonx" rather than "Json"
+    # to force the use of a "to_jsonx" method to convert
+    # documents to JSON. Using the more natural "Json"
+    # causes problems between our custom "to_json" and 
+    # Ruby's native "to_json"
+    class Jsonx < Base
+
+      def initialize(root, options)
+        super
+        @pretty_print = @options[:pretty_print] || false
+      end
 
       def convert(el)
         tree = get_tree(el)
-        tree.to_json
+        @pretty_print ? JSON.pretty_generate(tree) : JSON.generate(tree)
       end
 
       def get_tree(el)

--- a/lib/kramdown/converter/jsonx.rb
+++ b/lib/kramdown/converter/jsonx.rb
@@ -36,7 +36,7 @@ module Kramdown
       end
 
       def get_tree(el)
-        hash = {type: el.type}
+        hash = {:type => el.type}
         hash[:attr] = el.attr unless el.attr.empty?
         hash[:value] = el.value unless el.value.nil?
         unless el.children.empty?


### PR DESCRIPTION
Notice that I named the converter "Jsonx" to side-step an issue in which the code runs into conflicts with the Ruby's native "to_json". I believe the issue is in the code to automatically registers the converter but I am not sure. Thoughts?

If I name the class "Json" first call to to_json works as expected in the code below, but the second one does not.

```
puts Kramdown::Document.new(markdown).to_json
# => { the proper json goes here }

puts Kramdown::Document.new(markdown).to_json
# => "a string with the internal object ID is displayed here"
```