### PR TITLE
Implements an Abstract Syntax Tree converter that returns

### DIFF
--- a/lib/kramdown/converter.rb
+++ b/lib/kramdown/converter.rb
@@ -26,6 +26,7 @@ module Kramdown
     autoload :Toc, 'kramdown/converter/toc'
     autoload :RemoveHtmlTags, 'kramdown/converter/remove_html_tags'
     autoload :Pdf, 'kramdown/converter/pdf'
+    autoload :Ast, 'kramdown/converter/ast'
 
     extend ::Kramdown::Utils::Configurable
 

--- a/lib/kramdown/converter/ast.rb
+++ b/lib/kramdown/converter/ast.rb
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+#--
+# Copyright (C) 2009-2015 Thomas Leitner <t_leitner@gmx.at>
+#
+# This file is part of kramdown which is licensed under the MIT.
+#++
+#
+
+require 'kramdown/parser'
+require 'kramdown/converter'
+require 'kramdown/utils'
+
+module Kramdown
+
+  module Converter
+
+    # Converts a Kramdown::Document to an Abstract Syntax Tree. Returns
+    # hash object with the elements of the tree.
+    class Ast < Base
+
+      def convert(el)
+        get_tree(el)
+      end
+
+      def get_tree(el)
+        hash = {:type => el.type}
+        hash[:attr] = el.attr unless el.attr.empty?
+        hash[:value] = el.value unless el.value.nil?
+        hash[:options] = el.options unless el.options.empty?
+        unless el.children.empty?
+          hash[:children] = []
+          el.children.each {|child| hash[:children] << get_tree(child)}
+        end
+        hash
+      end
+
+    end
+
+  end
+end

--- a/lib/kramdown/utils/ordered_hash.rb
+++ b/lib/kramdown/utils/ordered_hash.rb
@@ -43,6 +43,11 @@ module Kramdown
           @data.has_key?(key)
         end
 
+        # Return +true+ if the hash contains no keys.
+        def empty?
+          @data.empty?
+        end
+
         # Set the value for the +key+ to +val+.
         def []=(key, val)
           @order << key if !@data.has_key?(key)


### PR DESCRIPTION
 a Ruby hash with the tree for the elements in the document.