### PR TITLE
Unicode support for footnote markers #281

### DIFF
--- a/lib/kramdown/parser/kramdown/extensions.rb
+++ b/lib/kramdown/parser/kramdown/extensions.rb
@@ -125,9 +125,9 @@ module Kramdown
       end
 
 
-      ALD_ID_CHARS = /[\w-]/
+      ALD_ID_CHARS = /[\p{Alnum}-]/
       ALD_ANY_CHARS = /\\\}|[^\}]/
-      ALD_ID_NAME = /\w#{ALD_ID_CHARS}*/
+      ALD_ID_NAME = /\p{Alnum}#{ALD_ID_CHARS}*/
       ALD_TYPE_KEY_VALUE_PAIR = /(#{ALD_ID_NAME})=("|')((?:\\\}|\\\2|[^\}\2])*?)\2/
       ALD_TYPE_CLASS_NAME = /\.(-?#{ALD_ID_NAME})/
       ALD_TYPE_ID_NAME = /#([A-Za-z][\w:-]*)/


### PR DESCRIPTION
This PR fixes #281 by adding Unicode equivalent for `\w` which is `\p{Alnum}` to kramdown's parser.

I had some problems with testing, since on my machine *many tests already fail*. Below test are the ones who fail with this change:
    Testing ./testcases/block/12_extension/options3.text                                    FAILED
    Testing ./testcases/block/12_extension/options.text                                     FAILED
    Testing ./testcases/block/16_toc/toc_exclude.text                                       FAILED
    Testing ./testcases/span/extension/options.text                                         FAILED 

If there are any issues let me know in order to fix them.