### PR TITLE
Add SmartyPants processor

### DIFF
--- a/lib/kramdown/parser/smartypants.rb
+++ b/lib/kramdown/parser/smartypants.rb
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+require 'kramdown/parser'
+
+module Kramdown
+  module Parser
+    class SmartyPants < Kramdown::Parser::Kramdown
+
+      def initialize(source, options)
+        super
+        @block_parsers = [:block_html]
+        @span_parsers =  [:smart_quotes, :html_entity, :typographic_syms, :span_html]
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This adds a minimal SmartyPants processor. It allows HTML to passthrough untouched, escapes special characters, and turns quotes into smart quotes and converts typographic characters.