### PR TITLE
Added strikethrough syntax to GitHub Flavored Markdown parser

### DIFF
--- a/doc/parser/gfm.page
+++ b/doc/parser/gfm.page
@@ -19,6 +19,7 @@ changes:
 * Support for fenced code blocks using three or more backticks has been added.
 * Hard line breaks in paragraphs are enforced by default (see option 'hard_wrap').
 * ATX headers need a whitespace character after the hash signs.
+* Strikethroughs can be created using two or more tildes surrounding a piece of text
 
 ## Options
 

--- a/doc/parser/gfm.page
+++ b/doc/parser/gfm.page
@@ -19,7 +19,7 @@ changes:
 * Support for fenced code blocks using three or more backticks has been added.
 * Hard line breaks in paragraphs are enforced by default (see option 'hard_wrap').
 * ATX headers need a whitespace character after the hash signs.
-* Strikethroughs can be created using two or more tildes surrounding a piece of text
+* Strikethroughs can be created using two tildes surrounding a piece of text
 
 ## Options
 

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -23,6 +23,10 @@ module Kramdown
           @block_parsers.delete(current)
           @block_parsers.insert(i, replacement)
         end
+
+        i = @span_parsers.index(:escaped_chars)
+        @span_parsers[i] = :escaped_chars_gfm if i
+        @span_parsers << :strikethrough_gfm
       end
 
       def parse
@@ -60,6 +64,30 @@ module Kramdown
       FENCED_CODEBLOCK_MATCH = /^(([~`]){3,})\s*?((\w[\w-]*)(?:\?\S*)?)?\s*?\n(.*?)^\1\2*\s*?\n/m
       define_parser(:codeblock_fenced_gfm, /^[~`]{3,}/, nil, 'parse_codeblock_fenced')
 
+      STRIKETHROUGH_DELIM = /~{2,}/
+      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}.+#{STRIKETHROUGH_DELIM}/m
+      define_parser(:strikethrough_gfm, STRIKETHROUGH_MATCH, '~~')
+
+      def parse_strikethrough_gfm
+        line_number = @src.current_line_number
+
+        if @src.scan(STRIKETHROUGH_DELIM)
+          el = Element.new(:html_element, 'del', {}, :category => :span, :line => line_number)
+          @tree.children << el
+          parse_spans(el, STRIKETHROUGH_DELIM)
+          @src.scan(STRIKETHROUGH_DELIM)
+        end
+      end
+
+      ESCAPED_CHARS_GFM = /\\([\\.*_+`<>()\[\]{}#!:\|"'\$=\-~])/
+
+      # Parse the backslash-escaped character at the current location.
+      def parse_escaped_chars_gfm
+        @src.pos += @src.matched_size
+        add_text(@src[1])
+      end
+
+      define_parser(:escaped_chars_gfm, ESCAPED_CHARS_GFM, '\\\\')
     end
   end
 end

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -64,8 +64,8 @@ module Kramdown
       FENCED_CODEBLOCK_MATCH = /^(([~`]){3,})\s*?((\w[\w-]*)(?:\?\S*)?)?\s*?\n(.*?)^\1\2*\s*?\n/m
       define_parser(:codeblock_fenced_gfm, /^[~`]{3,}/, nil, 'parse_codeblock_fenced')
 
-      STRIKETHROUGH_DELIM = /~{2,}/
-      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}.+#{STRIKETHROUGH_DELIM}/m
+      STRIKETHROUGH_DELIM = /~~/
+      STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}[^\s~](.*)[^\s~]#{STRIKETHROUGH_DELIM}/m
       define_parser(:strikethrough_gfm, STRIKETHROUGH_MATCH, '~~')
 
       def parse_strikethrough_gfm

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -299,6 +299,7 @@ class TestFiles < Minitest::Test
   # Generate test methods for gfm-to-html conversion
   Dir[File.dirname(__FILE__) + '/{testcases,testcases_gfm}/**/*.text'].each do |text_file|
     next if EXCLUDE_GFM_FILES.any? {|f| text_file =~ /#{f}$/}
+    next if RUBY_VERSION < '1.9'
     basename = text_file.sub(/\.text$/, '')
 
     html_file = [(".html.19" if RUBY_VERSION >= '1.9'), ".html"].compact.

--- a/test/testcases_gfm/strikethrough.html
+++ b/test/testcases_gfm/strikethrough.html
@@ -1,19 +1,25 @@
 <p><del>This is a test</del></p>
 
-<p><del>This is another test</del></p>
+<p>~<del>This is another test</del>~</p>
 
-<p><del>This is yet another test</del></p>
+<p><del>This is yet another test</del>~</p>
 
-<p><del>
-This
-is
-a
-<strong>multiline</strong>
-test
-</del></p>
+<p>~~ This is a test of it NOT working ~~</p>
+
+<p>~~<br />
+This<br />
+is<br />
+a<br />
+<strong>multiline</strong><br />
+test<br />
+~~</p>
 
 <p>This is an <del><em>inline</em> <strong>strikethrough</strong></del> test</p>
 
 <p>This is an ~~escaped~~ strikethrough.</p>
 
 <p>This is a <del>strikethrough with a ~ in the middle</del></p>
+
+<p>I <del>don’t even</del>~ have an extra tilde.</p>
+
+<p>This should ~~not be struck.</p>

--- a/test/testcases_gfm/strikethrough.html
+++ b/test/testcases_gfm/strikethrough.html
@@ -1,0 +1,19 @@
+<p><del>This is a test</del></p>
+
+<p><del>This is another test</del></p>
+
+<p><del>This is yet another test</del></p>
+
+<p><del>
+This
+is
+a
+<strong>multiline</strong>
+test
+</del></p>
+
+<p>This is an <del><em>inline</em> <strong>strikethrough</strong></del> test</p>
+
+<p>This is an ~~escaped~~ strikethrough.</p>
+
+<p>This is a <del>strikethrough with a ~ in the middle</del></p>

--- a/test/testcases_gfm/strikethrough.options
+++ b/test/testcases_gfm/strikethrough.options
@@ -1,0 +1,1 @@
+:input: 'GFM'

--- a/test/testcases_gfm/strikethrough.options
+++ b/test/testcases_gfm/strikethrough.options
@@ -1,1 +1,0 @@
-:input: 'GFM'

--- a/test/testcases_gfm/strikethrough.text
+++ b/test/testcases_gfm/strikethrough.text
@@ -4,6 +4,8 @@
 
 ~~This is yet another test~~~
 
+~~ This is a test of it NOT working ~~
+
 ~~
 This
 is
@@ -17,3 +19,7 @@ This is an ~~_inline_ **strikethrough**~~ test
 This is an \~~escaped~~ strikethrough.
 
 This is a ~~strikethrough with a ~ in the middle~~
+
+I ~~don't even~~~ have an extra tilde.
+
+This should ~~not be struck.

--- a/test/testcases_gfm/strikethrough.text
+++ b/test/testcases_gfm/strikethrough.text
@@ -1,0 +1,19 @@
+~~This is a test~~
+
+~~~This is another test~~~
+
+~~This is yet another test~~~
+
+~~
+This
+is
+a
+**multiline**
+test
+~~
+
+This is an ~~_inline_ **strikethrough**~~ test
+
+This is an \~~escaped~~ strikethrough.
+
+This is a ~~strikethrough with a ~ in the middle~~


### PR DESCRIPTION
Duplicates https://github.com/gettalong/kramdown/pull/184 by @diegobg. Fixes #304.

@gettalong We'd like to work with you to bring this GFM parser up to speed with the current offerings on GitHub. Expect some PR's to that effect in the coming weeks. Thank you for kramdown!