### PR TITLE
Update MathJax-node to mathjax-node (note case)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_install:
   - sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra tidy
   - gem install rake minitest coderay stringex rouge ritex itextomml
   - (ruby --version | grep -qv 'ruby 1.[89]') && gem install prawn prawn-table || true
-  - npm install MathJax-node
+  - npm install mathjax-node
 
 script: ruby -rubygems -Ilib:test test/test_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ before_install:
   - gem install rake minitest coderay stringex rouge ritex itextomml
   - (ruby --version | grep -qv 'ruby 1.[89]') && gem install prawn prawn-table || true
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
-  - npm install mathjax-node
+  - npm install mathjax-node cssstyle
 
 script: ruby -rubygems -Ilib:test test/test_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,16 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
-node_js:
-  - 0.10
-  - 4.0
+
+env:
+  - TRAVIS_NODE_VERSION="4.0"
 
 before_install:
   - sudo apt-get update
   - sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra tidy
   - gem install rake minitest coderay stringex rouge ritex itextomml
   - (ruby --version | grep -qv 'ruby 1.[89]') && gem install prawn prawn-table || true
+  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install mathjax-node
 
 script: ruby -rubygems -Ilib:test test/test_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.2.0
 node_js:
   - 0.10
+  - 4.0
 
 before_install:
   - sudo apt-get update

--- a/doc/math_engine/mathjaxnode.page
+++ b/doc/math_engine/mathjaxnode.page
@@ -9,7 +9,7 @@ can be used together with the [HTML converter](../converter/html.html).
 
 To use Mathjax-Node, set the option ['math_engine'](../options.html#option-math-engine) to
 'mathjaxnode' and make sure that both [Node.js](https://nodejs.org/) and Mathjax-Node are available.
-The Mathjax-Node library can be installed, e.g., via npm by running `npm install -g MathJax-node`.
+The Mathjax-Node library can be installed, e.g., via npm by running `npm install -g mathjax-node`.
 Instructions for installing Node.js can be found in the [joyent/node
 wiki](https://github.com/joyent/node/wiki/Installation).
 
@@ -25,4 +25,4 @@ texhints
   `false`, the TeX-specific classes, like `MJX-TeXAtom-ORD`, will not be added. These classes
   provide styling hints to the MathJax browser library.
 
-The MathJax-node library is released under the Apache License, Version 2.0.
+The mathjax-node library is released under the Apache License, Version 2.0.

--- a/lib/kramdown/converter/math_engine/mathjaxnode.rb
+++ b/lib/kramdown/converter/math_engine/mathjaxnode.rb
@@ -14,9 +14,13 @@ module Kramdown::Converter::MathEngine
 
     # MathjaxNode is available if this constant is +true+.
     AVAILABLE = RUBY_VERSION >= '1.9' && begin
-      %x{nodejs --version}[1..-2] >= '4.0'
+      %x{node --version}[1..-2] >= '4.0'
     rescue
-      false
+      begin
+        %x{nodejs --version}[1..-2] >= '4.0'
+      rescue
+        false
+      end
     end && begin
       npm = %x{npm --global --depth=1 list mathjax-node}
 

--- a/lib/kramdown/converter/math_engine/mathjaxnode.rb
+++ b/lib/kramdown/converter/math_engine/mathjaxnode.rb
@@ -9,19 +9,19 @@
 
 module Kramdown::Converter::MathEngine
 
-  # Uses the MathJax-node library for converting math formulas to MathML.
+  # Uses the mathjax-node library for converting math formulas to MathML.
   module MathjaxNode
 
     # MathjaxNode is available if this constant is +true+.
     AVAILABLE = RUBY_VERSION >= '1.9' && begin
-      npm = %x{npm --global --depth=1 list MathJax-node}
+      npm = %x{npm --global --depth=1 list mathjax-node}
 
-      unless /MathJax-node@/ === npm.lines.drop(1).join("\n")
-        npm = %x{npm --depth=1 list MathJax-node}
+      unless /mathjax-node@/ === npm.lines.drop(1).join("\n")
+        npm = %x{npm --depth=1 list mathjax-node}
       end
 
-      T2MPATH = File.join(npm.lines.first.strip, "node_modules/MathJax-node/bin/tex2mml")
-      /MathJax-node@/ === npm.lines.drop(1).join("\n") && File.exist?(T2MPATH)
+      T2MPATH = File.join(npm.lines.first.strip, "node_modules/mathjax-node/bin/tex2mml")
+      /mathjax-node@/ === npm.lines.drop(1).join("\n") && File.exist?(T2MPATH)
     rescue
       false
     end

--- a/lib/kramdown/converter/math_engine/mathjaxnode.rb
+++ b/lib/kramdown/converter/math_engine/mathjaxnode.rb
@@ -14,6 +14,10 @@ module Kramdown::Converter::MathEngine
 
     # MathjaxNode is available if this constant is +true+.
     AVAILABLE = RUBY_VERSION >= '1.9' && begin
+      %x{nodejs --version}[1..-2] >= '4.0'
+    rescue
+      false
+    end && begin
       npm = %x{npm --global --depth=1 list mathjax-node}
 
       unless /mathjax-node@/ === npm.lines.drop(1).join("\n")


### PR DESCRIPTION
Fix for failure reported in #240.

Replaces the deprecated `MathJax-node` library with `mathjax-node` (note the difference in case).