### PR TITLE
List supported parsers in Document docs

### DIFF
--- a/lib/kramdown/document.rb
+++ b/lib/kramdown/document.rb
@@ -92,9 +92,8 @@ module Kramdown
     # options that can be used are defined in the Options module.
     #
     # The special options key :input can be used to select the parser that should parse the
-    # +source+. It has to be the name of a class in the Kramdown::Parser module. For example, to
-    # select the kramdown parser, one would set the :input key to +Kramdown+. If this key is not
-    # set, it defaults to +Kramdown+.
+    # +source+. It must be the name of a class in the Kramdown::Parser module: +Base+, +Kramdown+,
+    # +Html+, +Markdown+, or +GFM+. If this key is not set, it defaults to +Kramdown+.
     #
     # The +source+ is immediately parsed by the selected parser so that the root element is
     # immediately available and the output can be generated.


### PR DESCRIPTION
It took me longer than it should to figure out how to get from `Kramdown::Document.new(text)` to `Kramdown::Document.new(text, :input => 'GFM')`. I couldn't find "GFM" in the docs (I had to read the source code to find it).

I suggest listing the available options at the same point where the `:input` param is mentioned. This PR does just that.

One downside of this approach is that it's an extra maintenance point which will require updating when a new parser is added. I think the added clarity for developers is worth the extra maintenance.