### PR TITLE
change Config::CONFIG to RbConfig::CONFIG

### DIFF
--- a/lib/kramdown/document.rb
+++ b/lib/kramdown/document.rb
@@ -53,7 +53,7 @@ module Kramdown
     unless defined?(@@data_dir)
       require 'rbconfig'
       @@data_dir = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'data', 'kramdown'))
-      @@data_dir = File.expand_path(File.join(Config::CONFIG["datadir"], "kramdown")) if !File.exists?(@@data_dir)
+      @@data_dir = File.expand_path(File.join(RbConfig::CONFIG["datadir"], "kramdown")) if !File.exists?(@@data_dir)
       raise "kramdown data directory not found! This is a bug, please report it!" unless File.directory?(@@data_dir)
     end
     @@data_dir


### PR DESCRIPTION
Config has been deprecated for a long time in favor of RbConfig and does not exist anymore since ruby2.2
In Debian, we rely on the 'datadir' config option to find the installed data.