### PR TITLE
No need to remove formatter from options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
@@ -14,7 +13,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra tidy
   - gem install rake --version 10.5.0
-  - gem install minitest coderay stringex rouge ritex itextomml
+  - gem install minitest coderay stringex ritex itextomml
+  - gem install rouge -v 1.10.1
   - (ruby --version | grep -qv 'ruby 1.[89]') && gem install prawn prawn-table || true
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install mathjax-node cssstyle

--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -27,7 +27,7 @@ module Kramdown::Converter::SyntaxHighlighter
       lexer = ::Rouge::Lexer.find_fancy(lang || opts[:default_lang], text)
       return nil if opts[:disable] || !lexer
 
-      formatter = (opts.delete(:formatter) || ::Rouge::Formatters::HTML).new(opts)
+      formatter = (opts.fetch(:formatter, ::Rouge::Formatters::HTML)).new(opts)
       formatter.format(lexer.lex(text))
     end
 

--- a/test/testcases/block/06_codeblock/rouge/multiple.html
+++ b/test/testcases/block/06_codeblock/rouge/multiple.html
@@ -1,0 +1,11 @@
+<div class="language-ruby highlighter-rouge"><div class="custom-class"><pre class="highlight"><code><span class="nb">puts</span> <span class="s2">"Hello"</span>
+</code></pre>
+</div></div>
+
+<div class="language-ruby highlighter-rouge"><div class="custom-class"><pre class="highlight"><code><span class="nb">puts</span> <span class="s2">"World"</span>
+</code></pre>
+</div></div>
+
+<div class="language-php highlighter-rouge"><div class="custom-class"><pre class="highlight"><code><span class="nv">$foo</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Bar</span><span class="p">;</span>
+</code></pre>
+</div></div>

--- a/test/testcases/block/06_codeblock/rouge/multiple.options
+++ b/test/testcases/block/06_codeblock/rouge/multiple.options
@@ -1,0 +1,4 @@
+:syntax_highlighter: rouge
+:syntax_highlighter_opts:
+  default_lang: ruby
+  formatter: !ruby/class 'RougeHTMLFormatters'

--- a/test/testcases/block/06_codeblock/rouge/multiple.text
+++ b/test/testcases/block/06_codeblock/rouge/multiple.text
@@ -1,0 +1,11 @@
+~~~ ruby
+puts "Hello"
+~~~
+
+~~~ ruby
+puts "World"
+~~~
+
+~~~ php?start_inline=1
+$foo = new Bar;
+~~~


### PR DESCRIPTION
If you remove formatter for options, this leave next code without this formatter. Example without fix:

![no fix](https://cloud.githubusercontent.com/assets/98444/17035574/cc347206-4f90-11e6-91ee-71e72672f2ca.png)

With fix:

![fix](https://cloud.githubusercontent.com/assets/98444/17035580/d230abde-4f90-11e6-8012-d52288af55bd.png)

