### PR TITLE
Strip transliterated head ids

### DIFF
--- a/lib/kramdown/converter/base.rb
+++ b/lib/kramdown/converter/base.rb
@@ -230,7 +230,7 @@ module Kramdown
       # Uses the option +auto_id_prefix+: the value of this option is prepended to every generated
       # ID.
       def generate_id(str)
-        str = ::Kramdown::Utils::Unidecoder.decode(str) if @options[:transliterated_header_ids]
+        str = ::Kramdown::Utils::Unidecoder.decode(str).strip if @options[:transliterated_header_ids]
         gen_id = basic_generate_id(str)
         gen_id = 'section' if gen_id.length == 0
         @used_ids ||= {}

--- a/test/testcases/block/04_header/with_auto_ids.html
+++ b/test/testcases/block/04_header/with_auto_ids.html
@@ -19,3 +19,5 @@
 <h1>Header without ID</h1>
 
 <h1 id="transliterated-day-la-vi-du">Transliterated: Đây-là-ví-dụ</h1>
+
+<h2 id="transliterated-biao-ti-er">Transliterated: 标题二</h2>

--- a/test/testcases/block/04_header/with_auto_ids.text
+++ b/test/testcases/block/04_header/with_auto_ids.text
@@ -22,3 +22,5 @@ Not now
 {: id=""}
 
 # Transliterated: Đây-là-ví-dụ
+
+## Transliterated: 标题二


### PR DESCRIPTION
source:

```
## Transliterated: 标题二
```

result:

```
<h2 id="biao-ti-er-">标题二</h2>
```

There's an extra `-` at the end of the header id, which is replaced from whitespace, we should strip it.
