### PR TITLE
GFM compatibility for list/blockquote/fenced codeblock and atx header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-latex-extra tidy
   - gem install rake --version 10.5.0
-  - gem install minitest coderay stringex rouge ritex itextomml
+  - gem install rouge --version 1.8
+  - gem install minitest coderay stringex ritex itextomml
   - (ruby --version | grep -qv 'ruby 1.[89]') && gem install prawn prawn-table || true
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - npm install mathjax-node cssstyle

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -18,7 +18,8 @@ module Kramdown
         super
         @span_parsers.delete(:line_break) if @options[:hard_wrap]
         {:codeblock_fenced => :codeblock_fenced_gfm,
-          :atx_header => :atx_header_gfm}.each do |current, replacement|
+          :atx_header => :atx_header_gfm,
+          :paragraph => :paragraph_gfm}.each do |current, replacement|
           i = @block_parsers.index(current)
           @block_parsers.delete(current)
           @block_parsers.insert(i, replacement)
@@ -59,10 +60,26 @@ module Kramdown
       end
 
       ATX_HEADER_START = /^\#{1,6}\s/
-      define_parser(:atx_header_gfm, ATX_HEADER_START, nil, 'parse_atx_header')
+      define_parser(:atx_header_gfm, ATX_HEADER_START)
 
+      # Copied from kramdown/parser/kramdown/header.rb, removed the first line
+      def parse_atx_header_gfm
+        start_line_number = @src.current_line_number
+        @src.check(ATX_HEADER_MATCH)
+        level, text, id = @src[1], @src[2].to_s.strip, @src[3]
+        return false if text.empty?
+
+        @src.pos += @src.matched_size
+        el = new_block_el(:header, nil, nil, :level => level.length, :raw_text => text, :location => start_line_number)
+        add_text(text, el)
+        el.attr['id'] = id if id
+        @tree.children << el
+        true
+      end
+
+      FENCED_CODEBLOCK_START = /^[~`]{3,}/
       FENCED_CODEBLOCK_MATCH = /^(([~`]){3,})\s*?((\S+?)(?:\?\S*)?)?\s*?\n(.*?)^\1\2*\s*?\n/m
-      define_parser(:codeblock_fenced_gfm, /^[~`]{3,}/, nil, 'parse_codeblock_fenced')
+      define_parser(:codeblock_fenced_gfm, FENCED_CODEBLOCK_START, nil, 'parse_codeblock_fenced')
 
       STRIKETHROUGH_DELIM = /~~/
       STRIKETHROUGH_MATCH = /#{STRIKETHROUGH_DELIM}[^\s~](.*?)[^\s~]#{STRIKETHROUGH_DELIM}/m
@@ -87,6 +104,8 @@ module Kramdown
       ESCAPED_CHARS_GFM = /\\([\\.*_+`<>()\[\]{}#!:\|"'\$=\-~])/
       define_parser(:escaped_chars_gfm, ESCAPED_CHARS_GFM, '\\\\', :parse_escaped_chars)
 
+      PARAGRAPH_END = /#{LAZY_END}|#{LIST_START}|#{ATX_HEADER_START}|#{DEFINITION_LIST_START}|#{BLOCKQUOTE_START}|#{FENCED_CODEBLOCK_START}/
+      define_parser(:paragraph_gfm, PARAGRAPH_START, nil, 'parse_paragraph')
     end
   end
 end

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -294,6 +294,7 @@ class TestFiles < Minitest::Test
                        'test/testcases/span/extension/comment.text',
                        'test/testcases/span/ial/simple.text',
                        'test/testcases/span/line_breaks/normal.text',
+                       'test/testcases/span/math/normal.text',
                        'test/testcases/span/text_substitutions/entities_as_char.text',
                        'test/testcases/span/text_substitutions/entities.text',
                        'test/testcases/span/text_substitutions/typography.text',

--- a/test/testcases_gfm/paragraph_end.html
+++ b/test/testcases_gfm/paragraph_end.html
@@ -1,0 +1,16 @@
+<p>A</p>
+<ul>
+  <li>b</li>
+</ul>
+
+<p>blockquote</p>
+<blockquote>
+  <p>text</p>
+</blockquote>
+
+<p>header</p>
+<h1>text</h1>
+
+<p>codeblock fenced</p>
+<pre><code>puts hello world
+</code></pre>

--- a/test/testcases_gfm/paragraph_end.text
+++ b/test/testcases_gfm/paragraph_end.text
@@ -1,0 +1,13 @@
+A
+  - b
+
+blockquote
+> text
+
+header
+# text
+
+codeblock fenced
+```
+puts hello world
+```


### PR DESCRIPTION
This PR fixes the issues described in #336 #359:

	A
	  - b

	blockquote
	> text

	header
	# text

	codeblock fenced
	```
	puts hello world
	```

kramdown result:

```html
<p>A<br />
  - b</p>

<p>blockquote<br />
&gt; text</p>

<p>header<br />
# text</p>

<p>codeblock fenced<br />
<code>
puts hello world
</code></p>
```

github result:

A
  - b

blockquote
> text

header
# text

codeblock fenced
```
puts hello world
```

-----------------------

**NOTES:**

- This PR breaks an existing test: `test/testcases/span/math/normal.text`, which I think can be safely disabled for GFM.
- Fixes travis-ci failure due to rouge 2.0 compatibility  issue #350