### PR TITLE
GFM: be more clever on parsing fenced codeblock

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -85,8 +85,8 @@ module Kramdown
         true
       end
 
-      FENCED_CODEBLOCK_START = /^[~`]{3,}/
-      FENCED_CODEBLOCK_MATCH = /^(([~`]){3,})\s*?((\S+?)(?:\?\S*)?)?\s*?\n(.*?)^\1\2*\s*?\n/m
+      FENCED_CODEBLOCK_START = /^[ ]{0,3}[~`]{3,}/
+      FENCED_CODEBLOCK_MATCH = /^[ ]{0,3}(([~`]){3,})\s*?((\S+?)(?:\?\S*)?)?\s*?\n(.*?)^[ ]{0,3}\1\2*\s*?\n/m
       define_parser(:codeblock_fenced_gfm, FENCED_CODEBLOCK_START, nil, 'parse_codeblock_fenced')
 
       STRIKETHROUGH_DELIM = /~~/

--- a/test/testcases_gfm/codeblock_fenced.html
+++ b/test/testcases_gfm/codeblock_fenced.html
@@ -1,0 +1,20 @@
+<p>normal</p>
+
+<pre><code class="language-ruby">require 'kramdown'
+
+Kramdown::Document.new(text).to_html
+</code></pre>
+
+<p>indent with tab</p>
+
+<pre><code>```ruby
+require 'kramdown'
+
+Kramdown::Document.new(text).to_html
+```
+</code></pre>
+
+<p>indent with 2 spaces</p>
+
+<pre><code class="language-js">  console.log("hello");
+</code></pre>

--- a/test/testcases_gfm/codeblock_fenced.options
+++ b/test/testcases_gfm/codeblock_fenced.options
@@ -1,0 +1,1 @@
+:enable_coderay: false

--- a/test/testcases_gfm/codeblock_fenced.text
+++ b/test/testcases_gfm/codeblock_fenced.text
@@ -1,0 +1,21 @@
+normal
+
+```ruby
+require 'kramdown'
+
+Kramdown::Document.new(text).to_html
+```
+
+indent with tab
+
+	```ruby
+	require 'kramdown'
+
+	Kramdown::Document.new(text).to_html
+	```
+
+indent with 2 spaces
+
+  ```js
+  console.log("hello");
+  ```


### PR DESCRIPTION
This pr adds support for fenced code block with whitespace before the ```

source:

``````
  ```js
  console.log("hello");
  ```
``````

github result:

``` js
  console.log("hello");
```

kramdown result:

```
<p><code>js
  console.log("hello");
 </code></p>
```
