### PR TITLE
Allow using tab as separator in table

### DIFF
--- a/lib/kramdown/parser/kramdown/table.rb
+++ b/lib/kramdown/parser/kramdown/table.rb
@@ -13,9 +13,9 @@ module Kramdown
   module Parser
     class Kramdown
 
-      TABLE_SEP_LINE = /^([+|: -]*?-[+|: -]*?)[ \t]*\n/
-      TABLE_HSEP_ALIGN = /[ ]?(:?)-+(:?)[ ]?/
-      TABLE_FSEP_LINE = /^[+|: =]*?=[+|: =]*?[ \t]*\n/
+      TABLE_SEP_LINE = /^([+|: \t-]*?-[+|: \t-]*?)[ \t]*\n/
+      TABLE_HSEP_ALIGN = /[ \t]?(:?)-+(:?)[ \t]?/
+      TABLE_FSEP_LINE = /^[+|: \t=]*?=[+|: \t=]*?[ \t]*\n/
       TABLE_ROW_LINE = /^(.*?)[ \t]*\n/
       TABLE_PIPE_CHECK = /(?:\||.*?[^\\\n]\|)/
       TABLE_LINE = /#{TABLE_PIPE_CHECK}.*?\n/

--- a/test/testcases/block/14_table/header.html
+++ b/test/testcases/block/14_table/header.html
@@ -94,3 +94,24 @@
     </tr>
   </tbody>
 </table>
+
+<p>Sep line with tab</p>
+
+<table>
+  <thead>
+    <tr>
+      <th style="text-align: right">right</th>
+      <th style="text-align: center">center</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td style="text-align: right">cell1</td>
+      <td style="text-align: center">cell2</td>
+    </tr>
+    <tr>
+      <td style="text-align: right">cell3</td>
+      <td style="text-align: center">cell4</td>
+    </tr>
+  </tbody>
+</table>

--- a/test/testcases/block/14_table/header.text
+++ b/test/testcases/block/14_table/header.text
@@ -30,3 +30,10 @@ Multiple bodies
 | cell3 | cell4
 |----|||
 | cell5 | cell6
+
+Sep line with tab
+
+right | center
+---:  	|	:---:
+cell1 | cell2
+cell3 | cell4


### PR DESCRIPTION
source:

```
right | center
---:    |   :---:
cell1 | cell2
cell3 | cell4
```

expect:

| right | center |
| --: | :-: |
| cell1 | cell2 |
| cell3 | cell4 |

actual:

```
<table>
  <tbody>
    <tr>
      <td>right</td>
      <td>center</td>
    </tr>
    <tr>
      <td>—:</td>
      <td>:—:</td>
    </tr>
    <tr>
      <td>cell1</td>
      <td>cell2</td>
    </tr>
    <tr>
      <td>cell3</td>
      <td>cell4</td>
    </tr>
  </tbody>
</table>
```

I'm using the GFM parser, but fix this in the GFM parser requires a lot of change, so the changes are made to the kramdown parser. Since this this a new feature, it may not affect the existing docs.
