### PR TITLE
Add preview_as_code option to mathjax engine

### DIFF
--- a/doc/math_engine/mathjax.page
+++ b/doc/math_engine/mathjax.page
@@ -25,5 +25,13 @@ preview
   preview with the LaTeX code itself is shown. If it is set to any value other than `false` or
   `true`, that value is shown as the preview.
 
+preview_as_code
+: When `true`, wraps the LaTeX code in `code` / `pre > code` tags instead of `span` / `div` tags,
+  mirroring the structure of inline code / code blocks.
+  This ensures the content is styled like regular code and improves legibility in RSS readers,
+  text browsers, etc.
+  To prevent styling issues after MathJax has loaded, consider adding
+  `.MathJax_Preview:empty{display:none}` to your CSS.
+  Defaults to `false` and expects `preview` to be `true`.
 
 [MathJax]: http://www.mathjax.org

--- a/lib/kramdown/converter/math_engine/mathjax.rb
+++ b/lib/kramdown/converter/math_engine/mathjax.rb
@@ -36,10 +36,22 @@ module Kramdown::Converter::MathEngine
 
       preview = (preview == true ? converter.escape_html(el.value) : preview.to_s)
 
+      preview_as_code = converter.options[:math_engine_opts][:preview_as_code] == true
+
       if el.options[:category] == :block
-        converter.format_as_block_html('div', {'class' => 'MathJax_Preview'}, preview, opts[:indent])
+        if preview_as_code
+          converter.format_as_block_html('pre', {'class' => 'MathJax_Preview'},
+            converter.format_as_span_html('code', {}, preview),
+            opts[:indent])
+        else
+          converter.format_as_block_html('div', {'class' => 'MathJax_Preview'}, preview, opts[:indent])
+        end
       else
-        converter.format_as_span_html('span', {'class' => 'MathJax_Preview'}, preview)
+        if preview_as_code
+          converter.format_as_span_html('code', {'class' => 'MathJax_Preview'}, preview)
+        else
+          converter.format_as_span_html('span', {'class' => 'MathJax_Preview'}, preview)
+        end
       end
     end
 

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -82,6 +82,7 @@ class TestFiles < Minitest::Test
                           'test/testcases/span/math/mathjaxnode.html', # bc of tidy
                           'test/testcases/block/15_math/mathjax_preview.html', # bc of mathjax preview
                           'test/testcases/block/15_math/mathjax_preview_simple.html', # bc of mathjax preview
+                          'test/testcases/block/15_math/mathjax_preview_as_code.html', # bc of mathjax preview
                           'test/testcases/span/05_html/mark_element.html', # bc of tidy
                           'test/testcases/block/09_html/xml.html', # bc of tidy
                           'test/testcases/span/05_html/xml.html', # bc of tidy
@@ -241,6 +242,7 @@ class TestFiles < Minitest::Test
                              'test/testcases/span/math/mathjaxnode.html', # bc of tidy
                              'test/testcases/block/15_math/mathjax_preview.html', # bc of mathjax preview
                              'test/testcases/block/15_math/mathjax_preview_simple.html', # bc of mathjax preview
+                             'test/testcases/block/15_math/mathjax_preview_as_code.html', # bc of mathjax preview
                              'test/testcases/span/01_link/link_defs_with_ial.html', # bc of attribute ordering
                              'test/testcases/span/05_html/mark_element.html', # bc of tidy
                              'test/testcases/block/09_html/xml.html', # bc of tidy

--- a/test/testcases/block/15_math/mathjax_preview_as_code.html
+++ b/test/testcases/block/15_math/mathjax_preview_as_code.html
@@ -1,0 +1,4 @@
+<p>This is a <code class="MathJax_Preview">5 + 5</code><script type="math/tex">5 + 5</script> statement</p>
+
+<pre class="MathJax_Preview"><code>5 + 5</code></pre>
+<script type="math/tex; mode=display">5 + 5</script>

--- a/test/testcases/block/15_math/mathjax_preview_as_code.options
+++ b/test/testcases/block/15_math/mathjax_preview_as_code.options
@@ -1,0 +1,3 @@
+:math_engine_opts:
+  :preview: true
+  :preview_as_code: true

--- a/test/testcases/block/15_math/mathjax_preview_as_code.text
+++ b/test/testcases/block/15_math/mathjax_preview_as_code.text
@@ -1,0 +1,5 @@
+This is a $$5 + 5$$ statement
+
+$$
+5 + 5
+$$


### PR DESCRIPTION
Adds a `preview_as_code` option to the mathjax engine.

When `true`,  wraps LaTeX previews in `code` / `pre > code` tags instead of `span` / `div` tags, mirroring the structure of inline code / code blocks. This ensures the content is styled like regular code and improves legibility in RSS readers like feedly or text browsers like lynx, etc. 

See in action:
![Preview latex code](http://i.giphy.com/26ufiT29sPlFVXwxG.gif)
