### PR TITLE
Add :disable_parsers option.

### DIFF
--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -245,6 +245,23 @@ Default: false
 Used by: HTML/Latex converter
 EOF
 
+    define(:disable_parsers, Object, [], <<EOF) do |val|
+List of parsers to disable
+
+Kramdown has a number of built-in span and block parsers, and
+additional parsers can be added by subclassing. This option allows the
+caller to disable specific parsers by name, especially when something
+like smart quotes or typographic dashes will be supplied by a separate
+processing step.
+
+Default: []
+Used by: kramdown parser
+EOF
+      val = simple_array_validator(val, :disable_parsers)
+      val.map! {|v| v.to_sym rescue v}
+      val
+    end
+
     define(:parse_block_html, Boolean, false, <<EOF)
 Process kramdown syntax in block HTML tags
 

--- a/lib/kramdown/parser/kramdown.rb
+++ b/lib/kramdown/parser/kramdown.rb
@@ -111,6 +111,10 @@ module Kramdown
       # Adapt the object to allow parsing like specified in the options.
       def configure_parser
         @parsers = {}
+        # Remove disabled parsers now; this is the first opportunity
+        # since subclasses might append in their initialization.
+        @block_parsers -= @options[:disable_parsers]
+        @span_parsers -= @options[:disable_parsers]
         (@block_parsers + @span_parsers).each do |name|
           if self.class.has_parser?(name)
             @parsers[name] = self.class.parser(name)

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -85,6 +85,7 @@ class TestFiles < Minitest::Test
                           'test/testcases/span/05_html/mark_element.html', # bc of tidy
                           'test/testcases/block/09_html/xml.html', # bc of tidy
                           'test/testcases/span/05_html/xml.html', # bc of tidy
+                          'test/testcases/span/text_substitutions/typography_disabled.html', # bc of tidy
                          ].compact
     EXCLUDE_HTML_TEXT_FILES = ['test/testcases/block/09_html/parse_as_span.htmlinput',
                                'test/testcases/block/09_html/parse_as_raw.htmlinput',
@@ -192,6 +193,7 @@ class TestFiles < Minitest::Test
                           'test/testcases/span/05_html/mark_element.text', # bc of tidy
                           'test/testcases/block/09_html/xml.text', # bc of tidy
                           'test/testcases/span/05_html/xml.text', # bc of tidy
+                          'test/testcases/span/text_substitutions/typography_disabled.text', # bc of tidy
                          ].compact
     Dir[File.dirname(__FILE__) + '/testcases/**/*.text'].each do |text_file|
       next if EXCLUDE_TEXT_FILES.any? {|f| text_file =~ /#{f}$/}
@@ -245,6 +247,7 @@ class TestFiles < Minitest::Test
                              'test/testcases/span/05_html/mark_element.html', # bc of tidy
                              'test/testcases/block/09_html/xml.html', # bc of tidy
                              'test/testcases/span/05_html/xml.html', # bc of tidy
+                             'test/testcases/span/text_substitutions/typography_disabled.html', # bc of tidy
                             ].compact
     Dir[File.dirname(__FILE__) + '/testcases/**/*.{html,html.19}'].each do |html_file|
       next if EXCLUDE_HTML_KD_FILES.any? {|f| html_file =~ /#{f}(\.19)?$/}
@@ -318,6 +321,7 @@ class TestFiles < Minitest::Test
                        'test/testcases/span/text_substitutions/entities_as_char.text',
                        'test/testcases/span/text_substitutions/entities.text',
                        'test/testcases/span/text_substitutions/typography.text',
+                       'test/testcases/span/text_substitutions/typography_disabled.text',
                        ('test/testcases/span/03_codespan/rouge/simple.text' if RUBY_VERSION < '2.0'),
                        ('test/testcases/span/03_codespan/rouge/disabled.text' if RUBY_VERSION < '2.0'),
                        ('test/testcases/block/06_codeblock/rouge/simple.text' if RUBY_VERSION < '2.0'), #bc of rouge

--- a/test/testcases/span/text_substitutions/typography_disabled.html
+++ b/test/testcases/span/text_substitutions/typography_disabled.html
@@ -1,0 +1,38 @@
+<p>This is... something---this too--!</p>
+
+<p>This &lt;<is>&gt; some text, &lt;&lt; this &gt;&gt; too!</is></p>
+
+<p>"Fancy quotes" are 'cool', even in the '80s!
+Je t' aime. You're a funny one! Thomas' name
+Mark's name. "...you"
+"'Nested' quotes are 'possible'", too!
+'"Otherway" is "round"'!</p>
+
+<p>'Opening now!'</p>
+
+<p>'80s are really cool.</p>
+
+<p><em>Cluster</em>'s Last Stand.</p>
+
+<p>Nam liber tempor
+"...At vero eos et accusam"</p>
+
+<p>"<em>Single underscores</em> should work."</p>
+
+<p>"<em>Single asterisks</em> should work."</p>
+
+<p>'<strong>Double underscores</strong> should work.'</p>
+
+<p>'<strong>Double asterisks</strong> should work.'</p>
+
+<p>"<em>Hurrah!</em>"</p>
+
+<p>'<strong>Absolutely</strong>.'</p>
+
+<p>"...some Text"</p>
+
+<p>"... some Text"</p>
+
+<p>This: "...some Text"</p>
+
+<p>This: "... some Text"</p>

--- a/test/testcases/span/text_substitutions/typography_disabled.options
+++ b/test/testcases/span/text_substitutions/typography_disabled.options
@@ -1,0 +1,2 @@
+:disable_parsers: typographic_syms,smart_quotes
+:entity_output: symbolic

--- a/test/testcases/span/text_substitutions/typography_disabled.text
+++ b/test/testcases/span/text_substitutions/typography_disabled.text
@@ -1,0 +1,38 @@
+This is... something---this too--!
+
+This <<is>> some text, << this >> too!
+
+"Fancy quotes" are 'cool', even in the '80s!
+Je t' aime. You're a funny one! Thomas' name
+Mark's name. "...you"
+"'Nested' quotes are 'possible'", too!
+'"Otherway" is "round"'!
+
+'Opening now!'
+
+'80s are really cool.
+
+<em>Cluster</em>'s Last Stand.
+
+Nam liber tempor
+"...At vero eos et accusam"
+
+"_Single underscores_ should work."
+
+"*Single asterisks* should work."
+
+'__Double underscores__ should work.'
+
+'**Double asterisks** should work.'
+
+"_Hurrah!_"
+
+'__Absolutely__.'
+
+"...some Text"
+
+"... some Text"
+
+This: "...some Text"
+
+This: "... some Text"


### PR DESCRIPTION
I'm using kramdown with jekyll, and I'd like to defer smart quotes and typographic dashes to [rubypants](https://github.com/jmcnevin/rubypants) via [jekyll-pants](https://github.com/scampersand/jekyll-pants). However kramdown makes this hard/impossible because there's no way to disable the built-in parsers.

(There is a workaround for smart quotes, which is to set `smart_quotes: apos,apos,quot,quot`, but this is clearly a hack and doesn't help for dashes and ellipses.)

This pull request adds :disable_parsers so that one could set `disable_parsers: typographic_syms,smart_quotes` to properly defer that processing. I made it generic rather than specific to those parsers since it seems like it could be generally useful.