### PR TITLE
Add header ID test case for headers with code spans

### DIFF
--- a/test/testcases_gfm/header_ids.html
+++ b/test/testcases_gfm/header_ids.html
@@ -15,3 +15,5 @@
 <h3 id="-1">;;</h3>
 
 <h3 id="before--after-tab">before 	after tab</h3>
+
+<h3 id="code-span"><code>code-span</code></h3>

--- a/test/testcases_gfm/header_ids.html.19
+++ b/test/testcases_gfm/header_ids.html.19
@@ -15,3 +15,5 @@
 <h3 id="-1">;;</h3>
 
 <h3 id="before--after-tab">before 	after tab</h3>
+
+<h3 id="code-span"><code>code-span</code></h3>

--- a/test/testcases_gfm/header_ids.text
+++ b/test/testcases_gfm/header_ids.text
@@ -15,3 +15,5 @@
 ### ;;
 
 ### before 	after tab
+
+### `code-span`


### PR DESCRIPTION
Note that this test will currently fail, due to #391 . 

[This page](https://github.com/nfagerlund/evil-made-manifest/blob/master/headerproblems.markdown#new-allow_ip-directive-in-authconf-ip-addresses-disallowed-in-allow-directive) has an extensive torture test of GitHub's header ID generation, demonstrating its behavior with code spans (among other things). 