### PR TITLE
Fix Footnote link spacing

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -453,9 +453,9 @@ module Kramdown
           end
 
           unless @options[:footnote_backlink].empty?
-            para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [insert_space ? ' ' : '', name, backlink_text])
+            para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [insert_space ? '&nbsp;' : '', name, backlink_text])
             (1..repeat).each do |index|
-              para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % [" ", "#{name}:#{index}", "#{backlink_text}<sup>#{index+1}</sup>"])
+              para.children << Element.new(:raw, FOOTNOTE_BACKLINK_FMT % ["&nbsp;", "#{name}:#{index}", "#{backlink_text}<sup>#{index+1}</sup>"])
             end
           end
 

--- a/test/testcases/block/12_extension/options.html
+++ b/test/testcases/block/12_extension/options.html
@@ -15,7 +15,7 @@ some <span>*para*</span>
 <div class="footnotes">
   <ol start="10">
     <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+      <p>Some text.&nbsp;<a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/12_extension/options2.html
+++ b/test/testcases/block/12_extension/options2.html
@@ -4,7 +4,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+      <p>Some text.&nbsp;<a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/16_toc/toc_with_footnotes.html
+++ b/test/testcases/block/16_toc/toc_with_footnotes.html
@@ -7,7 +7,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:1">
-      <p>Some footnote content here <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>Some footnote content here&nbsp;<a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/backlink_text.html
+++ b/test/testcases/span/04_footnote/backlink_text.html
@@ -3,7 +3,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:fn">
-      <p>Some text here <a href="#fnref:fn" class="reversefootnote">text &8617; &lt;img /&gt;</a></p>
+      <p>Some text here&nbsp;<a href="#fnref:fn" class="reversefootnote">text &8617; &lt;img /&gt;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/footnote_nr.html
+++ b/test/testcases/span/04_footnote/footnote_nr.html
@@ -3,10 +3,10 @@
 <div class="footnotes">
   <ol start="35">
     <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+      <p>Some text.&nbsp;<a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
     </li>
     <li id="fn:bc">
-      <p>Some other text. <a href="#fnref:bc" class="reversefootnote">&#8617;</a></p>
+      <p>Some other text.&nbsp;<a href="#fnref:bc" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/inside_footnote.html
+++ b/test/testcases/span/04_footnote/inside_footnote.html
@@ -5,13 +5,13 @@
 <div class="footnotes">
   <ol>
     <li id="fn:first">
-      <p>Consecutur adisping.<sup id="fnref:third"><a href="#fn:third" class="footnote">3</a></sup> <a href="#fnref:first" class="reversefootnote">&#8617;</a></p>
+      <p>Consecutur adisping.<sup id="fnref:third"><a href="#fn:third" class="footnote">3</a></sup>&nbsp;<a href="#fnref:first" class="reversefootnote">&#8617;</a></p>
     </li>
     <li id="fn:second">
-      <p>Sed ut perspiciatis unde omnis. <a href="#fnref:second" class="reversefootnote">&#8617;</a></p>
+      <p>Sed ut perspiciatis unde omnis.&nbsp;<a href="#fnref:second" class="reversefootnote">&#8617;</a></p>
     </li>
     <li id="fn:third">
-      <p>Sed ut. <a href="#fnref:third" class="reversefootnote">&#8617;</a></p>
+      <p>Sed ut.&nbsp;<a href="#fnref:third" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/markers.html
+++ b/test/testcases/span/04_footnote/markers.html
@@ -17,7 +17,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:fn">
-      <p>Some foot note text <a href="#fnref:fn" class="reversefootnote">&#8617;</a> <a href="#fnref:fn:1" class="reversefootnote">&#8617;<sup>2</sup></a> <a href="#fnref:fn:2" class="reversefootnote">&#8617;<sup>3</sup></a></p>
+      <p>Some foot note text&nbsp;<a href="#fnref:fn" class="reversefootnote">&#8617;</a>&nbsp;<a href="#fnref:fn:1" class="reversefootnote">&#8617;<sup>2</sup></a>&nbsp;<a href="#fnref:fn:2" class="reversefootnote">&#8617;<sup>3</sup></a></p>
     </li>
     <li id="fn:3">
       <p>other text
@@ -29,7 +29,7 @@ with more lines</p>
       <p><a href="#fnref:3" class="reversefootnote">&#8617;</a></p>
     </li>
     <li id="fn:1">
-      <p>some <em>text</em> <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>some <em>text</em>&nbsp;<a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
     </li>
     <li id="fn:now">
 

--- a/test/testcases/span/04_footnote/placement.html
+++ b/test/testcases/span/04_footnote/placement.html
@@ -1,7 +1,7 @@
 <div class="footnotes">
   <ol>
     <li id="fn:1">
-      <p>Footnote \` text <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p>Footnote \` text&nbsp;<a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/regexp_problem.html
+++ b/test/testcases/span/04_footnote/regexp_problem.html
@@ -8,7 +8,7 @@
   <ol>
     <li id="fn:note1">
 
-      <p>A note <a href="#fnref:note1" class="reversefootnote">&#8617;</a></p>
+      <p>A note&nbsp;<a href="#fnref:note1" class="reversefootnote">&#8617;</a></p>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
There is a white space in the DOM from the end of the footnote to the beginning of the `<a>` tag that serves as a reversefootnote. I'd love to be able to replace this white space to `&nbsp;`. What this would effectively do is ensure that the backlink could never get pushed down to its own line in the footnote. If there wasn't enough room for it on the previous line, then since it'd be connected to the final word in the footnote, then it would push both the final word and the link to the next line. 

Perhaps illustrations would help. Here's the old way: 

![](https://cl.ly/2G3d0h1i0o2i/Image%202016-12-15%20at%209.43.03%20AM.png)

And here's the new way: 

![](https://cl.ly/3h321D0E1T39/Image%202016-12-15%20at%209.44.01%20AM.png)

See how much better the latter looks? 