### PR TITLE
Support Rouge 1.x and 2.0

### DIFF
--- a/doc/syntax_highlighter/rouge.page
+++ b/doc/syntax_highlighter/rouge.page
@@ -11,6 +11,10 @@ To use Rouge, set the option ['syntax_highlighter'](../options.html#option-synta
 'rouge' and make sure that Rouge is available. The Rouge library can be installed, e.g., via
 Rubygems by running `gem install rouge`.
 
+Note that since Rouge 2.0 has breaking changes, Kramdown swaps formatter classes depending on
+Rouge version. By default, `Rouge::Formatters::HTMLLegacy` is used with Rouge 2.0 or later
+instead of `Rouge::Formatters::HTML` which is the default formatter with Rouge 1.x.
+
 The Rouge syntax highlighter supports the following keys of the option
 ['syntax_highlighter_opts'](../options.html#option-syntax-highlighter-opts):
 
@@ -18,7 +22,8 @@ default_lang
 : The default language that should be used when no language is set.
 
 formatter
-: A custom Rouge formatter class that should be used instead of `Rouge::Formatters::HTML`.
+: A custom Rouge formatter class that should be used instead of the following default formatter
+  (Rogue 1.x: `Rouge::Formatters::HTML` / Rogue 2.x: `Rouge::Formatters::HTMLLegacy`).
 
   Note that setting this key only makes sense using Ruby code because the value needs to be a class
   object!

--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -17,6 +17,14 @@ module Kramdown::Converter::SyntaxHighlighter
 
       # Highlighting via Rouge is available if this constant is +true+.
       AVAILABLE = true
+
+      begin
+        # Rouge::Formatters::HTMLLegacy is available on Rouge 2.0 or later
+        FORMATTER_CLASS = ::Rouge::Formatters::HTMLLegacy
+      rescue NameError
+        # Fallbacks to Rouge 1.x formatter if Rouge::Formatters::HTMLLegacy is not available
+        FORMATTER_CLASS = ::Rouge::Formatters::HTML
+      end
     rescue LoadError, SyntaxError
       AVAILABLE = false  # :nodoc:
     end
@@ -26,8 +34,8 @@ module Kramdown::Converter::SyntaxHighlighter
       call_opts[:default_lang] = opts[:default_lang]
       lexer = ::Rouge::Lexer.find_fancy(lang || opts[:default_lang], text)
       return nil if opts[:disable] || !lexer
-
-      formatter = (opts.fetch(:formatter, ::Rouge::Formatters::HTML)).new(opts)
+      opts[:css_class] ||= 'highlight' # For backward compatibility when using Rouge 2.0
+      formatter = (opts.fetch(:formatter, FORMATTER_CLASS)).new(opts)
       formatter.format(lexer.lex(text))
     end
 


### PR DESCRIPTION
This PR is kind of a draft proposal for supporting Rouge 2.0.

Since for the moment Kramdown supports Rouge < 2.0 which is considerably outdated, little by little it begins to hard to coexist with other gems which support Rouge >= 2.0 only.

I am still not sure what is the best way to support Rouge 2.0. Maybe we can support Rouge >= 2.0 only like other gems do (e.g. [middleman-syntax drops Rouge 1.x support](https://github.com/middleman/middleman-syntax/blob/270a86dd56220e069d55461ec570c73434de4a41/middleman-syntax.gemspec#L19)). However, I doubt that it is comfortable way for Kramdown because Rouge is an optional dependency and seem not to be easy to fix version to 2.0 or later.

So, this is the PR for supporting both Rouge 1.x and 2.0. Syntax highlighting will work just the same as before with Rouge 2.0, but it spoils some goodness, testability, for example.

How does this sound to you?

Related to https://github.com/gettalong/kramdown/issues/350