### PR TITLE
Added task list ability to GFM parser.

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -158,25 +158,24 @@ module Kramdown
       # elements where necessary (as well as applying classes to the ul/ol and li elements).
       def parse_list
         super
-        @tree.children.each do |element|
-          if [:ul, :ol].include? element.type
-            is_tasklist = false
-            element.children.each do |li|
-              # li -> p -> raw_text
-              checked = li.children[0].children[0].value.gsub!(
-                  /\[ \]\s+/, '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />')
-              unchecked = li.children[0].children[0].value.gsub!(
-                  /\[x\]\s+/i, '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />')
-              is_tasklist = (checked != nil or unchecked != nil)
-              if is_tasklist
-                li.attr[:class] = 'task-list-item'
-              end
-            end
-            if is_tasklist
-              element.attr[:class] = 'task-list'
-            end
-          end
+        current_list = @tree.children.select{ |element| [:ul, :ol].include?(element.type) }.last
+
+        is_tasklist = false
+        box_unchecked = '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />'
+        box_checked = '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />'
+
+        current_list.children.each do |li|
+          # li -> p -> raw_text
+          checked = li.children[0].children[0].value.gsub!(/\[ \]\s+/, box_unchecked)
+          unchecked = li.children[0].children[0].value.gsub!( /\[x\]\s+/i, box_checked)
+          is_tasklist ||= (!checked.nil? || !unchecked.nil?)
+
+          li.attr['class'] = 'task-list-item' if is_tasklist
         end
+
+        current_list.attr['class'] = 'task-list' if is_tasklist
+
+        true
       end
 
       ESCAPED_CHARS_GFM = /\\([\\.*_+`<>()\[\]{}#!:\|"'\$=\-~])/

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -154,6 +154,31 @@ module Kramdown
         el
       end
 
+      # To handle task-lists we override the parse method for lists, converting matching text into checkbox input
+      # elements where necessary (as well as applying classes to the ul/ol and li elements).
+      def parse_list
+        super
+        @tree.children.each do |element|
+          if [:ul, :ol].include? element.type
+            is_tasklist = false
+            element.children.each do |li|
+              # li -> p -> raw_text
+              checked = li.children[0].children[0].value.gsub!(
+                  /\[ \]\s+/, '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />')
+              unchecked = li.children[0].children[0].value.gsub!(
+                  /\[x\]\s+/i, '<input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />')
+              is_tasklist = (checked != nil or unchecked != nil)
+              if is_tasklist
+                li.attr[:class] = 'task-list-item'
+              end
+            end
+            if is_tasklist
+              element.attr[:class] = 'task-list'
+            end
+          end
+        end
+      end
+
       ESCAPED_CHARS_GFM = /\\([\\.*_+`<>()\[\]{}#!:\|"'\$=\-~])/
       define_parser(:escaped_chars_gfm, ESCAPED_CHARS_GFM, '\\\\', :parse_escaped_chars)
 

--- a/test/testcases_gfm/task_list.html
+++ b/test/testcases_gfm/task_list.html
@@ -1,0 +1,31 @@
+<p>unordered task list</p>
+
+<ul class="task-list">
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />first ul task item</li>
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />second ul task item</li>
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />third ul task item</li>
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />fourth ul task item</li>
+</ul>
+
+<p>unordered list</p>
+
+<ul>
+  <li>first ul item</li>
+  <li>second ul item</li>
+</ul>
+
+<p>ordered list</p>
+
+<ol>
+  <li>first ol item</li>
+  <li>second ol item</li>
+</ol>
+
+<p>ordered task list</p>
+
+<ol class="task-list">
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />first ol task item</li>
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />second ol task item</li>
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" checked="checked" />third ol task item</li>
+  <li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" disabled="disabled" />fourth ol task item</li>
+</ol>

--- a/test/testcases_gfm/task_list.text
+++ b/test/testcases_gfm/task_list.text
@@ -1,0 +1,23 @@
+unordered task list
+
+- [ ] first ul task item
+- [x] second ul task item
+- [X] third ul task item
+- [ ] fourth ul task item
+
+unordered list
+
+- first ul item
+- second ul item
+
+ordered list
+
+1. first ol item
+2. second ol item
+
+ordered task list
+
+1. [ ] first ol task item
+2. [x] second ol task item
+3. [X] third ol task item
+4. [ ] fourth ol task item


### PR DESCRIPTION
Followed most of the suggestions in #172. Never written Ruby before though so it may be a bit sloppy.

Currently renders as li disc followed by the checkbox, was assuming there'd be css to change `list-style-type` to `none` if the checkbox exists.  If not I can change it.

Thanks, Andrew.