### PR TITLE
Allow for passing Rouge formatter as a `String`

### DIFF
--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -15,14 +15,8 @@ require 'tmpdir'
 begin
   require 'kramdown/converter/syntax_highlighter/rouge'
 
-  class Kramdown::Converter::SyntaxHighlighter::Rouge::FORMATTER_CLASS
-    def format(tokens, &b)
-      super.sub(/<\/code><\/pre>\n?/, "</code></pre>\n")
-    end
-  end
-
   # custom formatter for tests
-  class RougeHTMLFormatters < Kramdown::Converter::SyntaxHighlighter::Rouge::FORMATTER_CLASS
+  class RougeHTMLFormatters < Kramdown::Converter::SyntaxHighlighter::Rouge.formatter_class({})
     tag 'rouge_html_formatters'
 
     def stream(tokens, &b)

--- a/test/testcases/block/06_codeblock/rouge/multiple.html
+++ b/test/testcases/block/06_codeblock/rouge/multiple.html
@@ -1,11 +1,8 @@
 <div class="language-ruby highlighter-rouge"><div class="custom-class"><div class="highlight"><pre class="highlight"><code><span class="nb">puts</span> <span class="s2">"Hello"</span>
-</code></pre>
-</div></div></div>
+</code></pre></div></div></div>
 
 <div class="language-ruby highlighter-rouge"><div class="custom-class"><div class="highlight"><pre class="highlight"><code><span class="nb">puts</span> <span class="s2">"World"</span>
-</code></pre>
-</div></div></div>
+</code></pre></div></div></div>
 
 <div class="language-php highlighter-rouge"><div class="custom-class"><div class="highlight"><pre class="highlight"><code><span class="nv">$foo</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Bar</span><span class="p">;</span>
-</code></pre>
-</div></div></div>
+</code></pre></div></div></div>

--- a/test/testcases/block/06_codeblock/rouge/multiple.options
+++ b/test/testcases/block/06_codeblock/rouge/multiple.options
@@ -1,4 +1,4 @@
 :syntax_highlighter: rouge
 :syntax_highlighter_opts:
   default_lang: ruby
-  formatter: !ruby/class 'RougeHTMLFormatters'
+  formatter: RougeHTMLFormatters

--- a/test/testcases/block/06_codeblock/rouge/simple.html
+++ b/test/testcases/block/06_codeblock/rouge/simple.html
@@ -1,10 +1,7 @@
 <div class="language-ruby highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="n">x</span> <span class="o">=</span> <span class="no">Class</span><span class="p">.</span><span class="nf">new</span>
-</code></pre>
-</div></div>
+</code></pre></div></div>
 <div class="language-html highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nt">&lt;a&gt;</span>href<span class="nt">&lt;/a&gt;</span>
-</code></pre>
-</div></div>
+</code></pre></div></div>
 
 <div class="language-php highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="nv">$foo</span> <span class="o">=</span> <span class="k">new</span> <span class="nx">Bar</span><span class="p">;</span>
-</code></pre>
-</div></div>
+</code></pre></div></div>


### PR DESCRIPTION
I thought this might be handy so that Jekyll users can change the Rouge formatter.