### PR TITLE
Add HTML tag removal for footnotes

### DIFF
--- a/lib/kramdown/converter/remove_html_tags.rb
+++ b/lib/kramdown/converter/remove_html_tags.rb
@@ -30,6 +30,10 @@ module Kramdown
       end
 
       def convert(el)
+        if el.type == :footnote
+          el = el.value
+        end
+
         children = el.children.dup
         index = 0
         while index < children.length


### PR DESCRIPTION
The existing `RemoveHtmlTags` converter does not handle footnotes:

```
doc = Kramdown::Document.new("Test[^1]\n\n[^1]: <script>alert(1);</script>")
Kramdown::Converter::RemoveHtmlTags.convert(doc.root, :remove_block_html_tags => true, :remove_span_html_tags => true)
```
```
Kramdown::Converter::Kramdown.convert(doc.root)
# => ["Test[^1]\n\n[^1]:\n    <script>alert(1);</script>\n\n", []]
```
```
Kramdown::Converter::Html.convert(doc.root)
# => ["<p>Test<sup id=\"fnref:1\"><a href=\"#fn:1\" class=\"footnote\">1</a></sup></p>\n\n<div class=\"footnotes\">\n  <ol>\n    <li id=\"fn:1\">\n      <script>alert(1);</script>\n\n      <p><a href=\"#fnref:1\" class=\"reversefootnote\">&#8617;</a></p>\n    </li>\n  </ol>\n</div>\n", []]
```

This PR attempts to address this. However, it's quite possible that there is a more sensible way to cover this.