### PR TITLE
GFM parser: option to disable typographic symbol conversion

### DIFF
--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -614,6 +614,13 @@ separated by commas. Possible names are:
   Note that if this quirk is used, lazy line wrapping does not fully
   work anymore!
 
+* no_auto_typographic
+
+  Disables automatic conversion of some characters into their
+  corresponding typographic symbols (like `--` to em-dash etc).
+  This helps to achieve results closer to what GitHub Flavored
+  Markdown produces.
+
 Default: paragraph_end
 Used by: GFM parser
 EOF

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -20,6 +20,7 @@ module Kramdown
         @id_counter = Hash.new(-1)
 
         @span_parsers.delete(:line_break) if @options[:hard_wrap]
+        @span_parsers.delete(:typographic_syms) if @options[:gfm_quirks].include?(:no_auto_typographic)
         if @options[:gfm_quirks].include?(:paragraph_end)
           atx_header_parser = :atx_header_gfm_quirk
           @paragraph_end = self.class::PARAGRAPH_END_GFM

--- a/test/testcases_gfm/no_typographic.html
+++ b/test/testcases_gfm/no_typographic.html
@@ -1,0 +1,3 @@
+<h3 id="header-with---ndash">Header with --ndash</h3>
+
+<h3 id="with------typographic---symbols">with --- &lt;&lt; typographic &gt;&gt; ... symbols</h3>

--- a/test/testcases_gfm/no_typographic.html.19
+++ b/test/testcases_gfm/no_typographic.html.19
@@ -1,0 +1,3 @@
+<h3 id="header-with---ndash">Header with --ndash</h3>
+
+<h3 id="with------typographic---symbols">with --- &lt;&lt; typographic &gt;&gt; ... symbols</h3>

--- a/test/testcases_gfm/no_typographic.options
+++ b/test/testcases_gfm/no_typographic.options
@@ -1,0 +1,1 @@
+:gfm_quirks: [no_auto_typographic]

--- a/test/testcases_gfm/no_typographic.text
+++ b/test/testcases_gfm/no_typographic.text
@@ -1,0 +1,3 @@
+### Header with --ndash
+
+### with --- << typographic >> ... symbols


### PR DESCRIPTION
With GFM, we want to be as close as possible to GitHub Flavored Markdown. In particular, GitHub does not replace `--` with en-dash, `---` with em-dash et cetera, and doing this not only breaks HTML rendering (resulting in, say, `–option` instead of `--option`), but also makes header IDs incompatible with those generated by GitHub. So, let's turn automatic typographic symbol conversion by default, and add an option to enable it back.

I have checked that this change makes header IDs the same as they are in GitHub.

For more details on the issue and examples, see https://github.com/gettalong/kramdown/issues/459

Signed-off-by: Kir Kolyshkin <kolyshkin@gmail.com>