### PR TITLE
Removed pdf-as-output from man page

### DIFF
--- a/man/man1/kramdown.1.erb
+++ b/man/man1/kramdown.1.erb
@@ -31,7 +31,7 @@ This file has to be in XDG_CONFIG_HOME on Linux/Unix, ~/Library/Preferences on m
 
 `-o` *FORMAT*, `--output` *FORMAT*
 : Specify one or more output formats separated by commas: *html* (default), *kramdown*, *latex*,
-  *pdf*, *man* or *remove_html_tags*.
+  *man* or *remove_html_tags*.
 
 `-v`, `--version`
 : Show the version of kramdown.


### PR DESCRIPTION
Kramdown support PDF output via LaTeX, it cannot natively generate a PDF.
Currently, passing `-o pdf` to the command line tool generates an error.