### PR TITLE
Expanded ToC example

### DIFF
--- a/doc/converter/html.page
+++ b/doc/converter/html.page
@@ -157,12 +157,21 @@ if no ID was set.
 When the `auto_ids` option is set, all headers will appear in the table of contents as they all will
 have an ID. Assign the class name "no_toc" to a header to exclude it from the table of contents.
 
-Here is an example:
+Here is an example that generates a "Table of Contents" as an unordered list:
 
-    # Contents
+    # Contents header
     {:.no_toc}
 
-    * Will be replaced with the ToC, excluding the "Contents" header
+    * A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+    {:toc}
+
+    # H1 header
+
+    ## H2 header
+
+For a "Table of Contents" as an ordered list:
+
+    1. The generated Toc will be an ordered list
     {:toc}
 
     # H1 header


### PR DESCRIPTION
Expanded the ToC doc to make it more clear that the {:toc} has to be used in conjunction with a markdown list, i.e. {:toc} is not a "valid" expression all by itself.

Ala https://stackoverflow.com/questions/48071478/table-of-contents-in-markdown-using-only-the-standard-out-of-the-box-github-p