### PR TITLE
Use non-deprecated SCSS color function.

### DIFF
--- a/doc/_design.scss
+++ b/doc/_design.scss
@@ -163,7 +163,7 @@ body {
     }
 
     a:hover, a:link {
-        color: $link-color / 2;
+        color: scale-color($link-color, $lightness: -50%);
     }
 }
 


### PR DESCRIPTION
This PR is to remove the following warning by `rake doc`:

~~~
DEPRECATION WARNING on line 166 of /_design.scss:
The operation `#1666A3 div 2` is deprecated and will be an error in future versions.
Consider using Sass's color functions instead.
http://sass-lang.com/documentation/Sass/Script/Functions.html#other_color_functions
~~~
My first attempt was to use `darken($link-color, 50%)` and that was wrong because apparently equivalent to `adjust-color($link-color, $lightness: -50%)`, resulting in `black`. The original intent is equivalent to `scale-color($link-color, $lightness: -50%)` so I have used that.

Verified that the resulting CSS is the same as in the `master` branch.