### PR TITLE
Upgrade CI's node version to avoid mathjax-node errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 
 env:
   global:
-    - TRAVIS_NODE_VERSION="4.5"
+    - TRAVIS_NODE_VERSION="6.0"
 
 matrix:
   allow_failures:

--- a/test/testcases/block/15_math/mathjaxnode.html.19
+++ b/test/testcases/block/15_math/mathjaxnode.html.19
@@ -1,4 +1,4 @@
-<math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="f(x) = a{x^3} + b{x^2} + cx + d">
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="f left-parenthesis x right-parenthesis equals a x cubed plus b x squared plus c x plus d">
   <mi>f</mi>
   <mo stretchy="false">(</mo>
   <mi>x</mi>

--- a/test/testcases/block/15_math/mathjaxnode_notexhints.html.19
+++ b/test/testcases/block/15_math/mathjaxnode_notexhints.html.19
@@ -1,4 +1,4 @@
-<math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="f(x) = a{x^3} + b{x^2} + cx + d">
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="f left-parenthesis x right-parenthesis equals a x cubed plus b x squared plus c x plus d">
   <mi>f</mi>
   <mo stretchy="false">(</mo>
   <mi>x</mi>

--- a/test/testcases/block/15_math/mathjaxnode_semantics.html.19
+++ b/test/testcases/block/15_math/mathjaxnode_semantics.html.19
@@ -1,4 +1,4 @@
-<math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="f(x) = a{x^3} + b{x^2} + cx + d">
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="f left-parenthesis x right-parenthesis equals a x cubed plus b x squared plus c x plus d">
   <semantics>
     <mrow>
       <mi>f</mi>

--- a/test/testcases/span/math/mathjaxnode.html.19
+++ b/test/testcases/span/math/mathjaxnode.html.19
@@ -1,4 +1,4 @@
-<p>This is <math xmlns="http://www.w3.org/1998/Math/MathML" alttext="f(x) = a{x^3} + b{x^2} + cx + d">
+<p>This is <math xmlns="http://www.w3.org/1998/Math/MathML" alttext="f left-parenthesis x right-parenthesis equals a x cubed plus b x squared plus c x plus d">
   <mi>f</mi>
   <mo stretchy="false">(</mo>
   <mi>x</mi>


### PR DESCRIPTION
`mathjax-node` now seems to require `node >= 6.0.0` (check the CI errors on #482).