### PR TITLE
Rcfile options and their application to test output updates

### DIFF
--- a/bin/kramdown
+++ b/bin/kramdown
@@ -27,11 +27,7 @@ begin
 rescue
 end
 
-options = if config_file && File.exist?(config_file)
-            YAML.safe_load(File.read(config_file), [Symbol])
-          else
-            {}
-          end
+options = {}
 format = ['html']
 
 OptionParser.new do |opts|
@@ -46,7 +42,14 @@ OptionParser.new do |opts|
           "html, GFM or markdown") {|v| options[:input] = v}
   opts.on("-o", "--output ARG", Array, "Specify one or more output formats separated by commas: " \
           "html (default),", "kramdown, latex, pdf, man or remove_html_tags") {|v| format = v}
-
+  opts.separator ""
+  opts.on("--no-config-file", "Do not read any configuration file. Default behavior is to check " \
+          "for a", "configuration file and read it if it exists.") {config_file = nil}
+  opts.on("--config-file FILE", "Specify the name of a configuration file with kramdown options " \
+          "in YAML", "format, e.g. \"auto_id_prefix: ARG\" instead of \"--auto-id-prefix ARG\"",
+          "and \"auto_ids: false\" instead of \"--no-auto-ids\".",
+          "Default: #{config_file}") {|v| config_file = v}
+  opts.separator ""
   opts.on("-v", "--version", "Show the version of kramdown") do
     puts Kramdown::VERSION
     exit
@@ -79,6 +82,17 @@ OptionParser.new do |opts|
 end.parse!
 
 begin
+  if config_file && File.exist?(config_file)
+    config_file_options = YAML.safe_load(File.read(config_file), [Symbol])
+    case config_file_options
+    when nil  # empty configuration file except perhaps YAML header and comments
+      # Nothing to do
+    when Hash
+      options = config_file_options.merge(options)
+    else
+      raise Kramdown::Error, "No YAML map in configuration file \"#{config_file}\""
+    end
+  end
   doc = Kramdown::Document.new(ARGF.read, options)
   result = ''
   format.each {|f| result = doc.send("to_#{f}")}

--- a/man/man1/kramdown.1.erb
+++ b/man/man1/kramdown.1.erb
@@ -20,9 +20,10 @@ used directly by the kramdown binary. The second set of options controls how kra
 converts its input.
 
 Default values for this second set can be set using YAML via the configuration file `kramdownrc`.
-Note that configuration option names use underscores, not dahes (dashes are just used in the CLI
-options names). This file has to be in XDG_CONFIG_HOME on Linux/Unix, ~/Library/Preferences on macOS
-and ~/AppData/Local on Windows.
+Note that configuration option names use underscores, not dashes (dashes are just used in the CLI
+options names), and boolean options do not have a `no` variant but a value of `true` or `false`.
+This file has to be in XDG_CONFIG_HOME on Linux/Unix, ~/Library/Preferences on macOS and
+~/AppData/Local on Windows.
 
 ## CLI-ONLY OPTIONS
 
@@ -33,6 +34,13 @@ and ~/AppData/Local on Windows.
 `-o` *FORMAT*, `--output` *FORMAT*
 : Specify one or more output formats separated by commas: *html* (default), *kramdown*, *latex*,
   *pdf*, *man* or *remove_html_tags*.
+
+`--no-config-file`
+: Do not read any configuration file. Default behavior is to check for a configuration file and
+  read it if it exists.
+
+`--config-file` *FILE*
+: Override the default path and name of the configuration file.
 
 `-v`, `--version`
 : Show the version of kramdown.


### PR DESCRIPTION
This short sequence of commits introduces
1. New CLI-only options `-n`, `--no-rcfile` and `-r` *FILE*, `--rcfile` *FILE* that control whether to load a `kramdownrc` file as well as its pathname. The `-n` ensures that no `kramdownrc` can influence the output of your invocation of `bin/kramdown`, and the `-r` *FILE* replaces the default configuration with that contained in *FILE*. With those, generating test reference outputs from the command line can be done as follows:

   ~~~ shell
   ruby -Ilib bin/kramdown -r mytest.options mytest.text >mytest.html
   ~~~
   Note that `mytest.options` does not need to exist. As `kramdownrc` is optional, so is the file named with `-r`.
2. An update to `Rakefile` that makes use of those options. The existing targets `dev:test_*_deps` and `dev:update_*_tests` have made use of `bin/kramdown` before; those invocations are now protected from `kramdownrc` influence and look more like the example above. Also, instead of manually enumerating test file names in the `Rakefile`, globs are used now.
3. New `Rakefile` targets for the MathjaxNode engine similar to those for SsKaTeX and KaTeX. Concretely, a new target `dev:update_mathjaxnode_tests` and its dependency `dev:test_mathjaxnode_deps` which does some sanity checking as to whether MathjaxNode actually works.

With those, the recent MathjaxNode test reference output updates could have been accomplished with the command

~~~ shell
rake dev:update_mathjaxnode_tests
~~~
And the output (if a working mathjax-node-cli is installed) would be

~~~ shell-session
NO RELEASE NOTES/CHANGES FILE
MathjaxNode is available, and its default configuration works.
/home/ccorn/.rvm/rubies/ruby-2.4.2/bin/ruby -Ilib bin/kramdown -r test/testcases/span/math/mathjaxnode.options test/testcases/span/math/mathjaxnode.text >test/testcases/span/math/mathjaxnode.html.19
/home/ccorn/.rvm/rubies/ruby-2.4.2/bin/ruby -Ilib bin/kramdown -r test/testcases/block/15_math/mathjaxnode_notexhints.options test/testcases/block/15_math/mathjaxnode_notexhints.text >test/testcases/block/15_math/mathjaxnode_notexhints.html.19
/home/ccorn/.rvm/rubies/ruby-2.4.2/bin/ruby -Ilib bin/kramdown -r test/testcases/block/15_math/mathjaxnode.options test/testcases/block/15_math/mathjaxnode.text >test/testcases/block/15_math/mathjaxnode.html.19
/home/ccorn/.rvm/rubies/ruby-2.4.2/bin/ruby -Ilib bin/kramdown -r test/testcases/block/15_math/mathjaxnode_semantics.options test/testcases/block/15_math/mathjaxnode_semantics.text >test/testcases/block/15_math/mathjaxnode_semantics.html.19
~~~
