### PR TITLE
Minor optimizations with faster alternatives

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -420,14 +420,14 @@ module Kramdown
         res = "footnotes" << (res.strip.empty? ? '' : " #{res}") if (el.type == :ul || el.type == :ol) &&
           (el.options[:ial][:refs].include?('footnotes') rescue nil)
         if el.type == :dl && el.options[:ial] && el.options[:ial][:refs]
-          auto_ids = el.options[:ial][:refs].select {|ref| ref =~ /\Aauto_ids/}.join(" ")
+          auto_ids = el.options[:ial][:refs].select {|ref| ref.start_with?('auto_ids')}.join(" ")
           res = auto_ids << (res.strip.empty? ? '' : " #{res}") unless auto_ids.empty?
         end
         res.strip.empty? ? nil : "{:#{res}}"
       end
 
       def parse_title(attr)
-        attr.to_s.empty? ? '' : ' "' + attr.gsub(/"/, '&quot;') + '"'
+        attr.to_s.empty? ? '' : ' "' + attr.gsub('"', '&quot;') + '"'
       end
 
       # :startdoc:

--- a/lib/kramdown/converter/syntax_highlighter/coderay.rb
+++ b/lib/kramdown/converter/syntax_highlighter/coderay.rb
@@ -28,7 +28,7 @@ module Kramdown::Converter::SyntaxHighlighter
         ::CodeRay.scan(text, lang.to_sym).html(options(converter, :span)).chomp
       elsif type == :block && (lang || options(converter, :default_lang))
         lang ||= call_opts[:default_lang] = options(converter, :default_lang)
-        ::CodeRay.scan(text, lang.to_s.gsub(/-/, '_').to_sym).html(options(converter, :block)).chomp << "\n"
+        ::CodeRay.scan(text, lang.to_s.tr('-', '_').to_sym).html(options(converter, :block)).chomp << "\n"
       else
         nil
       end

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -432,7 +432,7 @@ EOF
       else
         raise Kramdown::Error, "Invalid type #{val.class} for option toc_levels"
       end
-      if val.any? {|i| !(1..6).include?(i)}
+      if val.any? {|i| !(1..6).cover?(i)}
         raise Kramdown::Error, "Level numbers for option toc_levels have to be integers from 1 to 6"
       end
       val


### PR DESCRIPTION
- `Range#cover?` is [faster](https://github.com/JuanitoFatas/fast-ruby#cover-vs-include-code) than `Range#include?`
- `String#gsub` is [slower](https://github.com/JuanitoFatas/fast-ruby#stringgsub-vs-stringtr-code) than `String#tr` (for like numbered replacements)
- `String#gsub regex` is slower than `String#gsub str`
- Prefer native methods over regexp when possible