### PR TITLE
Ruby versions older than 2.0 are not supported

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -101,7 +101,7 @@ module Kramdown
         item.options[:raw_text] = raw_text
       end
 
-      NON_WORD_RE = (RUBY_VERSION > "1.9" ? /[^\p{Word}\- \t]/ : /[^\w\- \t]/)
+      NON_WORD_RE = /[^\p{Word}\- \t]/
 
       def generate_gfm_header_id(text)
         result = text.downcase

--- a/lib/kramdown/utils.rb
+++ b/lib/kramdown/utils.rb
@@ -37,21 +37,8 @@ module Kramdown
       name
     end
 
-    if RUBY_VERSION < '2.0'
-
-      # Resolve the recursive constant +str+.
-      def self.deep_const_get(str)
-        names = str.split(/::/)
-        names.shift if names.first.empty?
-        names.inject(::Object) {|mod, s| mod.const_get(s)}
-      end
-
-    else
-
-      def self.deep_const_get(str)
-        ::Object.const_get(str)
-      end
-
+    def self.deep_const_get(str)
+      ::Object.const_get(str)
     end
 
   end


### PR DESCRIPTION
Teardown checks for unsupported Ruby versions in `lib/` files