### PR TITLE
Optimize "setext" header parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 htmldoc
 pkg
 webgen-tmp
+.bundle/
+CONTRIBUTERS
+VERSION
+kramdown.gemspec
+man/man1/kramdown.1


### PR DESCRIPTION
Fixes #505

This is a proof-of-concept, I may not have time to address comments / clean up this PR (@gettalong @krasnoukhov feel free to close this and submit a clean version).

Benchmark "setext":

```bash
ruby -rbenchmark -Ilib -rkramdown -e 'p Benchmark.measure{Kramdown::Document.new("1#{" "*20000}2\n==\n")}'
```

Benchmark "atx" (still slow):

```bash
ruby -rbenchmark -Ilib -rkramdown -e 'p Benchmark.measure{Kramdown::Document.new("## 1#{" "*20000}2")}'
```