### PR TITLE
Optimize header parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 htmldoc
 pkg
 webgen-tmp
+.bundle/
+CONTRIBUTERS
+VERSION
+kramdown.gemspec
+man/man1/kramdown.1
+node_modules/
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
 htmldoc
 pkg
 webgen-tmp
-.bundle/
-CONTRIBUTERS
-VERSION
-kramdown.gemspec
-man/man1/kramdown.1
-node_modules/
-package-lock.json

--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -112,22 +112,16 @@ module Kramdown
         @options[:auto_id_prefix] + result
       end
 
-      ATX_HEADER_START = /^\#{1,6}\s/
+      ATX_HEADER_START = /^(?<level>\#{1,6})[\t ]+(?<contents>.*)\n/
       define_parser(:atx_header_gfm, ATX_HEADER_START, nil, 'parse_atx_header')
       define_parser(:atx_header_gfm_quirk, ATX_HEADER_START)
 
       # Copied from kramdown/parser/kramdown/header.rb, removed the first line
       def parse_atx_header_gfm_quirk
-        start_line_number = @src.current_line_number
-        @src.check(ATX_HEADER_MATCH)
-        level, text, id = @src[1], @src[2].to_s.strip, @src[3]
+        text, id = parse_header_contents
+        text.sub!(/[\t ]#+\z/, '') && text.rstrip!
         return false if text.empty?
-
-        @src.pos += @src.matched_size
-        el = new_block_el(:header, nil, nil, :level => level.length, :raw_text => text, :location => start_line_number)
-        add_text(text, el)
-        el.attr['id'] = id if id
-        @tree.children << el
+        add_header(@src["level"].length, text, id)
         true
       end
 

--- a/lib/kramdown/parser/kramdown/header.rb
+++ b/lib/kramdown/parser/kramdown/header.rb
@@ -43,7 +43,7 @@ module Kramdown
 
       HEADER_ID = /[\t ]{#(?<id>[A-Za-z][\w:-]*)}\z/
 
-      # @return [[String, String]] header text and optional ID.
+      # Returns header text and optional ID.
       def parse_header_contents
         text = @src["contents"]
         text.rstrip!
@@ -56,9 +56,6 @@ module Kramdown
         [text, id]
       end
 
-      # @param [Number] level
-      # @param [String] text
-      # @param [String, nil] id
       def add_header(level, text, id)
         start_line_number = @src.current_line_number
         @src.pos += @src.matched_size

--- a/lib/kramdown/parser/kramdown/header.rb
+++ b/lib/kramdown/parser/kramdown/header.rb
@@ -13,7 +13,7 @@ module Kramdown
   module Parser
     class Kramdown
 
-      SETEXT_HEADER_START = /^#{OPT_SPACE}(?<contents>.*)\n(?<level>[-=])[-=]*[ \t\r\f\v]*\n/
+      SETEXT_HEADER_START = /^#{OPT_SPACE}(?<contents>[^ \t].*)\n(?<level>[-=])[-=]*[ \t\r\f\v]*\n/
 
       # Parse the Setext header at the current location.
       def parse_setext_header
@@ -26,7 +26,7 @@ module Kramdown
       define_parser(:setext_header, SETEXT_HEADER_START)
 
 
-      ATX_HEADER_START = /^(?<level>\#{1,6})[\t ]*(?<contents>.*)\n/
+      ATX_HEADER_START = /^(?<level>\#{1,6})[\t ]*(?<contents>[^ \t].*)\n/
 
       # Parse the Atx header at the current location.
       def parse_atx_header


### PR DESCRIPTION
Fixes #505

Benchmarks:

"setext":

```bash
ruby -rbenchmark -Ilib -rkramdown -e 'p Benchmark.measure{Kramdown::Document.new("1#{" "*20000}2\n==\n")}'
```

"atx":

```bash
ruby -rbenchmark -Ilib -rkramdown -e 'p Benchmark.measure{Kramdown::Document.new("## 1#{" "*20000}2")}'
```