### PR TITLE
resolves #519 support backslash hard line break for GFM when hard_wrap is off

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -48,9 +48,9 @@ module Kramdown
 
       def update_elements(element)
         element.children.map! do |child|
-          if child.type == :text && @options[:hard_wrap] && child.value =~ /\n/
+          if child.type == :text && child.value.include?(hard_line_break = "#{@options[:hard_wrap] ? '' : '\\'}\n")
             children = []
-            lines = child.value.split(/\n/, -1)
+            lines = child.value.split(hard_line_break, -1)
             omit_trailing_br = (Kramdown::Element.category(element) == :block && element.children[-1] == child &&
                                 lines[-1].empty?)
             lines.each_with_index do |line, index|

--- a/test/testcases_gfm/hard_line_breaks_off.html
+++ b/test/testcases_gfm/hard_line_breaks_off.html
@@ -1,2 +1,5 @@
 <p>This is just a normal paragraph.<br />
 Containing a manual line break above.</p>
+
+<p>It was the best of times,<br />
+it was the worst of times.</p>

--- a/test/testcases_gfm/hard_line_breaks_off.text
+++ b/test/testcases_gfm/hard_line_breaks_off.text
@@ -1,2 +1,5 @@
 This is just a normal paragraph.  
 Containing a manual line break above.
+
+It was the best of times,\
+it was the worst of times.


### PR DESCRIPTION
When the input is GFM and the hard_wrap option is off, support the backslash variant of the hard line break.

```
foo\
bar
```

I also optimized how the lines are split in both cases.