### PR TITLE
GFM autolink

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -7,7 +7,7 @@
 #++
 #
 
-
+require 'uri'
 require 'kramdown/parser'
 
 module Kramdown
@@ -38,6 +38,11 @@ module Kramdown
 
         i = @span_parsers.index(:escaped_chars)
         @span_parsers[i] = :escaped_chars_gfm if i
+
+        i = nil
+        i = @span_parsers.index(:autolink)
+        @span_parsers[i] = :autolink_gfm if i
+
         @span_parsers << :strikethrough_gfm
       end
 
@@ -181,6 +186,17 @@ module Kramdown
 
       def paragraph_end
         @paragraph_end
+      end
+
+      define_parser(:autolink_gfm, URI::regexp(%w(http https)))
+
+      def parse_autolink_gfm
+        start_line_number = @src.current_line_number
+        @src.pos += @src.matched_size
+        href = @src[0]
+        el = Element.new(:a, nil, {'href' => href}, :location => start_line_number)
+        add_text(@src[0], el)
+        @tree.children << el
       end
 
     end

--- a/test/test_location.rb
+++ b/test/test_location.rb
@@ -227,6 +227,35 @@ describe 'location' do
     end
   end
 
+  it 'handles GFM autolinks - valid link' do
+    strs = %w(http://www.example.com
+      http://www.example.com/
+      http://example.com/abc/def
+      http://example.com/abc?def=ghi
+    )
+    strs.each do |link_text|
+      str = "def #{link_text} ghi"
+      doc = Kramdown::Document.new(str, :input => 'GFM')
+      children = doc.root.children.first.children
+      assert_equal "def ", children.first.value
+      assert_equal " ghi", children.last.value
+      link = children[1]
+      assert_equal :a, link.type
+      assert_equal link_text, link.attr['href']
+      assert_equal link_text, link.children.first.value
+    end
+  end
+
+  it 'handles GFM autolinks - invalid link' do
+    strs = ["www.example.com"]
+    strs.each do |str|
+      doc = Kramdown::Document.new(str, :input => 'GFM')
+      children = doc.root.children.first.children
+      assert_equal 1, children.length
+      assert_equal str, children.first.value
+    end
+  end
+
   it 'marks fenced code block as fenced with the GFM parser' do
     str = %(```\nfenced code\n```\n\n    indented code\n)
     doc = Kramdown::Document.new(str, :input => 'GFM')


### PR DESCRIPTION
This implements the ability to parse a http/https link to html, e.g. `http://www.example.com`.
It fixes https://github.com/gettalong/kramdown/issues/306.