### PR TITLE
duplicate frozen string

### DIFF
--- a/lib/kramdown/converter/math_engine/katex.rb
+++ b/lib/kramdown/converter/math_engine/katex.rb
@@ -27,6 +27,7 @@ module Kramdown::Converter::MathEngine
       attr = el.attr.dup
       attr.delete('xmlns')
       attr.delete('display')
+      result = result.dup
       result.insert(result =~ /[[:space:]>]/, converter.html_attributes(attr))
       result = "#{' ' * opts[:indent]}#{result}\n" if display_mode
       result


### PR DESCRIPTION
I am experiencing an error when using KaTeX with Kramdown from Jekyll-3.8.3. By duplicating this string (which unfreezes it) my site build proceeds normally.

Original error:

```
  Rendering Markup: _posts/2013-10-04-finding-a-spring-constant.md
  Conversion error: Jekyll::Converters::Markdown encountered an error while converting '_posts/2013-10-04-finding-a-spring-constant.md':
                    can't modify frozen String
bundler: failed to load command: jekyll (/home/xpm/.asdf/installs/ruby/2.4.1/bin/jekyll)
RuntimeError: can't modify frozen String
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/math_engine/katex.rb:30:in `insert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/math_engine/katex.rb:30:in `call'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/base.rb:221:in `format_math'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/html.rb:320:in `convert_math'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/html.rb:70:in `block in inner'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/html.rb:69:in `each'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/html.rb:69:in `inner'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/html.rb:341:in `convert_root'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/html.rb:57:in `convert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/converter/base.rb:105:in `convert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/kramdown-1.17.0/lib/kramdown/document.rb:117:in `method_missing'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/converters/markdown/kramdown_parser.rb:40:in `convert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/converters/markdown.rb:77:in `convert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:101:in `block in convert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:99:in `each'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:99:in `reduce'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:99:in `convert'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:83:in `render_document'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/renderer.rb:62:in `run'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:479:in `render_regenerated'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:464:in `block (2 levels) in render_docs'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:463:in `each'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:463:in `block in render_docs'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:462:in `each_value'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:462:in `render_docs'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:191:in `render'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/site.rb:71:in `process'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/command.rb:28:in `process_site'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/commands/build.rb:65:in `build'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/commands/build.rb:36:in `process'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/commands/serve.rb:93:in `block in start'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/commands/serve.rb:93:in `each'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/commands/serve.rb:93:in `start'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
  /home/xpm/.asdf/installs/ruby/2.4.1/lib/ruby/gems/2.4.0/gems/jekyll-3.8.3/exe/jekyll:15:in `<top (required)>'
  /home/xpm/.asdf/installs/ruby/2.4.1/bin/jekyll:22:in `load'
  /home/xpm/.asdf/installs/ruby/2.4.1/bin/jekyll:22:in `<top (required)>'
```