### PR TITLE
Run Travis tests with Bundler.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,23 @@ matrix:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install texlive-latex-base texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra tidy
-  - gem install rake
-  - gem install minitest coderay stringex ritex execjs sskatex
-  - "ruby -e 'exit RUBY_VERSION < \"2.3\" ? 0 : 1' || gem install katex -v 0.4.3"
-  - gem install rouge
-  - gem install prawn prawn-table
-  - (ruby --version | grep jruby) || gem install itextomml
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+  - |
+    sudo apt-get install \
+      texlive-latex-base \
+      texlive-latex-recommended \
+      texlive-fonts-recommended \
+      texlive-latex-extra \
+      tidy
+  - gem install bundler
+  - |
+    rm -rf ~/.nvm && \
+    git clone https://github.com/creationix/nvm.git ~/.nvm && \
+    pushd ~/.nvm && \
+    git checkout `git describe --abbrev=0 --tags` && \
+    popd && \
+    source ~/.nvm/nvm.sh && \
+    nvm install $TRAVIS_NODE_VERSION
   - npm install mathjax-node-cli cssstyle
   - curl -L 'https://github.com/Khan/KaTeX/releases/download/v0.9.0/katex.tar.gz' | tar xzf - 'katex/katex.min.js'
 
-script: ruby -Ilib:test test/test_*
+script: bundle exec ruby -Ilib:test test/test_*

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gem 'rake'
+gem 'minitest'
+gem 'coderay'
+gem 'stringex'
+gem 'ritex'
+gem 'execjs'
+gem 'sskatex'
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3')
+  gem 'katex', '0.4.3'
+end
+
+gem 'rouge'
+gem 'prawn'
+gem 'prawn-table'
+gem 'itextomml', platform: :ruby


### PR DESCRIPTION
There are code to check `RUBY_VERSION` and ruby or jruby on Travis CI.
Using Bundler makes the logic simpler.

It is also good to reproduce running unit tests on developer's environment, as they can install the dependency gem packages under this project directory.

```
$ bundle install --path vendor/bundle
```

As a default behavior of `language: ruby`, `bundle install --jobs=3 --retry=3` is run in the install section on Travis.
