### PR TITLE
Update gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-htmldoc
-pkg
-webgen-tmp
-CONTRIBUTERS
-VERSION
-kramdown.gemspec
-man/man1/kramdown.1
+/htmldoc
+/pkg
+/webgen-tmp
+/CONTRIBUTERS
+/VERSION
+/kramdown.gemspec
+/man/man1/kramdown.1
+/node_modules
+/katex


### PR DESCRIPTION
* Add "/" to ignore the top directories.
* Add ignored nvm install directory and katex directory that are created after installing the dependency packages.

For example, currently when creating below file `test/pkg/a.txt`, the file is ignored unintentionally.

```
$ mkdir test/pkg/
$ touch test/pkg/a.txt
```

But after this pull-request, it is appeared.

```
$ git status
On branch hotfix/gitignore
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	test/pkg/
```

