### PR TITLE
Add Travis build status badge on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kramdown
+# kramdown [![Build Status](https://travis-ci.org/gettalong/kramdown.svg?branch=master)](https://travis-ci.org/gettalong/kramdown)
 
 ## Readme first!
 


### PR DESCRIPTION
Shall we add the Travis build status badge?
We can check the status easily.

I referred rubygems' case for the position of the badge. [1]

Here is the modified README by this pull-request.
You can check it.
https://github.com/junaruga/kramdown/blob/feature/ci-build-status-badge/README.md

[1] https://github.com/rubygems/rubygems/blob/master/README.md

