### PR TITLE
[WIP] Implement render_source_location option

### DIFF
--- a/doc/converter/html.page
+++ b/doc/converter/html.page
@@ -184,7 +184,7 @@ For a "Table of Contents" as an ordered list:
 
 The HTML converter supports the following options:
 
-{options: {items: [auto_ids, auto_id_prefix, auto_id_stripping, transliterated_header_ids, template, footnote_nr, entity_output, smart_quotes, toc_levels, enable_coderay, coderay_wrap, coderay_line_numbers, coderay_line_number_start, coderay_tab_width, coderay_bold_every, coderay_css, coderay_default_lang, syntax_highlighter, syntax_highlighter_opts, math_engine, math_engine_opts, footnote_backlink, footnote_backlink_inline, typographic_symbols]}}
+{options: {items: [auto_ids, auto_id_prefix, auto_id_stripping, transliterated_header_ids, template, footnote_nr, entity_output, smart_quotes, toc_levels, enable_coderay, coderay_wrap, coderay_line_numbers, coderay_line_number_start, coderay_tab_width, coderay_bold_every, coderay_css, coderay_default_lang, syntax_highlighter, syntax_highlighter_opts, math_engine, math_engine_opts, footnote_backlink, footnote_backlink_inline, typographic_symbols, :render_source_location]}}
 
 
 {include_file: doc/links.markdown}

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -87,7 +87,7 @@ module Kramdown
         if el.options[:transparent]
           inner(el, indent)
         else
-          format_as_block_html(el.type, attr, inner(el, indent), indent, el.options[:location])
+          format_as_block_html(el.type, el.attr, inner(el, indent), indent, el.options[:location])
         end
       end
 

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -640,6 +640,18 @@ Default: false
 Used by: HTML converter
 EOF
 
+    define(:render_source_location, Boolean, false, <<EOF)
+Specifies whether the linenumber in the input source on which an element
+is defined should be added to the rendered result.
+
+Setting this option to true adds a `data-sourcepos` attribute to the
+rendered element with the value of the linenumber in the input source
+on which the element was defined. Only applies to block-level elements.
+
+Default: false
+Used by: HTML converter
+EOF
+
     define(:gfm_quirks, Object, [:paragraph_end], <<EOF) do |val|
 Enables a set of GFM specific quirks
 

--- a/test/test_location.rb
+++ b/test/test_location.rb
@@ -235,4 +235,9 @@ describe 'location' do
     assert fenced_cb.options[:fenced]
     refute indented_cb.options[:fenced]
   end
+
+  it 'adds location to rendered html attributes if enabled' do
+    doc = Kramdown::Document.new(test_cases['header'].gsub(/^      /, '').strip, :render_source_location => true)
+    assert_match /<h2.*data-sourcepos=\"4\"/, doc.to_html
+  end
 end


### PR DESCRIPTION
It would be great if kramdown could support basic sourcemapping, i.e., inlcuding source position in the rendered output. `commonmarker`, for example, is [already doing this](https://github.com/gjtorikian/commonmarker#passing-options). The `location` option is already being set by the parsers, so it's just a matter of adding it to the result produced by the `Converter`. (`commonmarker` sets the beginning *and* the end line, but just knowing the starting line of e.g. a header element in the source would already be very useful, for instance [in gollum](https://github.com/gollum/gollum-lib/pull/310))

I've added support for this for HTML block level elements (for which I think the need for this would be greatest). I realize the implementation is not perfect, but would like to improve it if the maintainers agree this would be a useful function, and give me some pointers.