### PR TITLE
Add data attribute to code highlighted by Rouge

### DIFF
--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -28,7 +28,9 @@ module Kramdown::Converter::SyntaxHighlighter
       return nil if opts[:disable] || !lexer
       opts[:css_class] ||= 'highlight' # For backward compatibility when using Rouge 2.0
       formatter = formatter_class(opts).new(opts)
-      formatter.format(lexer.lex(text))
+      formatter.format(lexer.lex(text)).sub(
+        '<code>', "<code data-lang=\"#{lang}\">"
+      )
     end
 
     def self.options(converter, type)

--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -28,9 +28,8 @@ module Kramdown::Converter::SyntaxHighlighter
       return nil if opts[:disable] || !lexer
       opts[:css_class] ||= 'highlight' # For backward compatibility when using Rouge 2.0
       formatter = formatter_class(opts).new(opts)
-      formatter.format(lexer.lex(text)).sub(
-        '<code>', "<code data-lang=\"#{lang}\">"
-      )
+      result = formatter.format(lexer.lex(text))
+      lang ? result.sub('<code>', "<code data-lang=\"#{lang}\">") : result
     end
 
     def self.options(converter, type)


### PR DESCRIPTION
Given the following fenced-code-block:

    ```ruby
    "Hello World"
    ```

This proposal would result in the following markup:
```html
<div class="language-ruby highlighter-rouge">
  <div class="highlight">
    <pre class="highlight">
      <code data-lang="ruby">
        <span class="s2">"Hello World"</span>
      </code>
    </pre>
  </div>
</div>
```
## Use-case
I can then use the data attribute to render a **language label** adjacent to the code-block to inform the reader **what language that code block is about**.

I'll update the test scenario once you're on board with the change