### PR TITLE
Remove non-essential files from the distribution

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -118,17 +118,16 @@ EOF
   end
 
   PKG_FILES = FileList.new([
-                            'Rakefile',
-                            'setup.rb',
-                            'COPYING', 'README.md', 'AUTHORS',
-                            'VERSION', 'CONTRIBUTERS',
+                            'AUTHORS',
                             'bin/*',
-                            'benchmark/*',
+                            'CONTRIBUTERS',
+                            'COPYING',
+                            'data/**/*',
                             'lib/**/*.rb',
                             'man/man1/kramdown.1',
-                            'data/**/*',
-                            'doc/**',
-                            'test/**/*'
+                            'README.md',
+                            'test/**/*',
+                            'VERSION'
                            ])
 
   CLOBBER << "VERSION"


### PR DESCRIPTION
Just as I've done with nokogiri recently (https://github.com/sparklemotion/nokogiri/pull/1719), I'd like to trim the size of this package (the one published to rubygems) so that installations are faster and the gem takes up less space on disk. So what I've attempted to do here is include only the files that are essential to kramdown's functionality, plus the software license which seems like it should be included in all distributions.