### PR TITLE
Avoid allocating memory for unused block parameter

### DIFF
--- a/lib/kramdown/converter.rb
+++ b/lib/kramdown/converter.rb
@@ -42,7 +42,7 @@ module Kramdown
         if !klass.const_defined?(:AVAILABLE) || klass::AVAILABLE
           add_syntax_highlighter(kn_down, klass)
         else
-          add_syntax_highlighter(kn_down) {|*args| nil}
+          add_syntax_highlighter(kn_down) { nil }
         end
         syntax_highlighter(kn_down).call(converter, text, lang, type, opts)
       end
@@ -58,7 +58,7 @@ module Kramdown
         if !klass.const_defined?(:AVAILABLE) || klass::AVAILABLE
           add_math_engine(kn_down, klass)
         else
-          add_math_engine(kn_down) {|*args| nil}
+          add_math_engine(kn_down) { nil }
         end
         math_engine(kn_down).call(converter, el, opts)
       end

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -138,10 +138,10 @@ module Kramdown
 
       def convert_ul(el, indent)
         if !@toc_code && (el.options[:ial][:refs].include?('toc') rescue nil)
-          @toc_code = [el.type, el.attr, (0..128).to_a.map{|a| rand(36).to_s(36)}.join]
+          @toc_code = [el.type, el.attr, (0..128).to_a.map { rand(36).to_s(36) }.join]
           @toc_code.last
         elsif !@footnote_location && el.options[:ial] && (el.options[:ial][:refs] || []).include?('footnotes')
-          @footnote_location = (0..128).to_a.map{|a| rand(36).to_s(36)}.join
+          @footnote_location = (0..128).to_a.map { rand(36).to_s(36) }.join
         else
           format_as_indented_block_html(el.type, el.attr, inner(el, indent), indent)
         end

--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -511,7 +511,7 @@ module Kramdown
         8194 => ['\hskip .5em\relax'],
         8195 => ['\quad'],
       } # :nodoc:
-      ENTITY_CONV_TABLE.each {|k,v| ENTITY_CONV_TABLE[k][0].insert(-1, '{}')}
+      ENTITY_CONV_TABLE.each_key { |k| ENTITY_CONV_TABLE[k][0].insert(-1, '{}') }
 
       def entity_to_latex(entity)
         text, package = ENTITY_CONV_TABLE[entity.code_point]
@@ -606,7 +606,7 @@ module Kramdown
         "["  => "{[}",
         "]"  => "{]}",
       }.merge(Hash[*("{}$%&_#".scan(/./).map {|c| [c, "\\#{c}"]}.flatten)]) # :nodoc:
-      ESCAPE_RE = Regexp.union(*ESCAPE_MAP.collect {|k,v| k}) # :nodoc:
+      ESCAPE_RE = Regexp.union(*ESCAPE_MAP.keys) # :nodoc:
 
       # Escape the special LaTeX characters in the string +str+.
       def escape(str)

--- a/lib/kramdown/converter/math_engine/sskatex.rb
+++ b/lib/kramdown/converter/math_engine/sskatex.rb
@@ -34,7 +34,7 @@ module Kramdown::Converter::MathEngine
       KTXC = ::Kramdown::Utils::LRUCache.new(10)
 
       # A logger that routes messages to the debug channel only. No need to create this dynamically.
-      DEBUG_LOGGER = lambda { |level, &expr| warn(expr.call) }
+      DEBUG_LOGGER = lambda { |_level, &expr| warn(expr.call) }
 
       class << self
         private

--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -458,7 +458,7 @@ module Kramdown
           def available_width
             return super unless @document.respond_to?(:converter) && @document.converter
 
-            @document.image_floats.each do |pn, x, y, w, h|
+            @document.image_floats.each do |pn, _x, y, w, h|
               next if @document.page_number != pn
               if @at[1] + @baseline_y <= y - @document.bounds.absolute_bottom &&
                   (@at[1] + @baseline_y + @arranger.max_line_height + @leading >= y - h - @document.bounds.absolute_bottom)

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -69,7 +69,7 @@ module Kramdown
     # Return a Hash with the default values for all options.
     def self.defaults
       temp = {}
-      @options.each {|n, o| temp[o.name] = o.default}
+      @options.each_value {|o| temp[o.name] = o.default}
       temp
     end
 
@@ -296,7 +296,7 @@ Default: {}
 Used by: kramdown parser
 EOF
       val = simple_hash_validator(val, :link_defs)
-      val.each do |k,v|
+      val.each_value do |v|
         if !(Array === v) || v.size > 2 || v.size < 1
           raise Kramdown::Error, "Invalid structure for hash value of option #{name}"
         end

--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -111,7 +111,7 @@ module Kramdown
         # contain only lowercase letters.
         def parse_html_attributes(str, line = nil, in_html_tag = true)
           attrs = Utils::OrderedHash.new
-          str.scan(HTML_ATTRIBUTE_RE).each do |attr, val, sep, quoted_val|
+          str.scan(HTML_ATTRIBUTE_RE).each do |attr, val, _sep, quoted_val|
             attr.downcase! if in_html_tag
             if attrs.has_key?(attr)
               warning("Duplicate HTML attribute '#{attr}' on line #{line || '?'} - overwriting previous one")

--- a/lib/kramdown/parser/kramdown.rb
+++ b/lib/kramdown/parser/kramdown.rb
@@ -90,7 +90,7 @@ module Kramdown
         update_tree(@root)
         correct_abbreviations_attributes
         replace_abbreviations(@root)
-        @footnotes.each do |name,data|
+        @footnotes.each_value do |data|
           update_tree(data[:content])
           replace_abbreviations(data[:content])
         end

--- a/lib/kramdown/parser/kramdown/extensions.rb
+++ b/lib/kramdown/parser/kramdown/extensions.rb
@@ -114,7 +114,7 @@ module Kramdown
             else
               true
             end
-          end.each do |k,v|
+          end.each_key do |k|
             warning("Unknown kramdown option '#{k}'")
           end
           @tree.children << new_block_el(:eob, :extension) if type == :block

--- a/lib/kramdown/parser/kramdown/html.rb
+++ b/lib/kramdown/parser/kramdown/html.rb
@@ -122,7 +122,7 @@ module Kramdown
           end
 
           attrs = parse_html_attributes(@src[2], line, HTML_ELEMENT[tag_name])
-          attrs.each {|name, value| value.gsub!(/\n+/, ' ')}
+          attrs.each { |_name, value| value.gsub!(/\n+/, ' ') }
 
           do_parsing = (HTML_CONTENT_MODEL[tag_name] == :raw || @tree.options[:content_model] == :raw ? false : @options[:parse_span_html])
           if val = HTML_MARKDOWN_ATTR_MAP[attrs.delete('markdown')]

--- a/lib/kramdown/parser/kramdown/link.rb
+++ b/lib/kramdown/parser/kramdown/link.rb
@@ -66,7 +66,7 @@ module Kramdown
         link_type = (result =~ /^!/ ? :img : :a)
 
         # no nested links allowed
-        if link_type == :a && (@tree.type == :img || @tree.type == :a || @stack.any? {|t,s| t && (t.type == :img || t.type == :a)})
+        if link_type == :a && (@tree.type == :img || @tree.type == :a || @stack.any? { |t, _s| t && (t.type == :img || t.type == :a) })
           add_text(result)
           return
         end

--- a/lib/kramdown/parser/kramdown/list.rb
+++ b/lib/kramdown/parser/kramdown/list.rb
@@ -72,7 +72,7 @@ module Kramdown
             item.value, indentation, content_re, lazy_re, indent_re = parse_first_list_line(@src[1].length, @src[2])
             list.children << item
 
-            item.value.sub!(self.class::LIST_ITEM_IAL) do |match|
+            item.value.sub!(self.class::LIST_ITEM_IAL) do
               parse_attribute_list($1, item.options[:ial] ||= {})
               ''
             end
@@ -190,7 +190,7 @@ module Kramdown
             item.value, indentation, content_re, lazy_re, indent_re = parse_first_list_line(@src[1].length, @src[2])
             deflist.children << item
 
-            item.value.sub!(self.class::LIST_ITEM_IAL) do |match|
+            item.value.sub!(self.class::LIST_ITEM_IAL) do
               parse_attribute_list($1, item.options[:ial] ||= {})
               ''
             end

--- a/lib/kramdown/parser/kramdown/smart_quotes.rb
+++ b/lib/kramdown/parser/kramdown/smart_quotes.rb
@@ -157,7 +157,7 @@ module Kramdown
       # Parse the smart quotes at current location.
       def parse_smart_quotes
         start_line_number = @src.current_line_number
-        substs = SQ_RULES.find {|reg, subst| @src.scan(reg)}[1]
+        substs = SQ_RULES.find { |reg, _subst| @src.scan(reg) }[1]
         substs.each do |subst|
           if subst.kind_of?(Integer)
             add_text(@src[subst])

--- a/lib/kramdown/parser/kramdown/typographic_symbol.rb
+++ b/lib/kramdown/parser/kramdown/typographic_symbol.rb
@@ -16,7 +16,7 @@ module Kramdown
                           ['<< ', :laquo_space], [' >>', :raquo_space],
                           ['<<', :laquo], ['>>', :raquo]]
       TYPOGRAPHIC_SYMS_SUBST = Hash[*TYPOGRAPHIC_SYMS.flatten]
-      TYPOGRAPHIC_SYMS_RE = /#{TYPOGRAPHIC_SYMS.map {|k,v| Regexp.escape(k)}.join('|')}/
+      TYPOGRAPHIC_SYMS_RE = /#{TYPOGRAPHIC_SYMS.map { |k, _v| Regexp.escape(k) }.join('|')}/
 
       # Parse the typographic symbols at the current location.
       def parse_typographic_syms

--- a/lib/kramdown/parser/markdown.rb
+++ b/lib/kramdown/parser/markdown.rb
@@ -43,7 +43,7 @@ module Kramdown
       PARAGRAPH_END = LAZY_END
 
       IAL_RAND_CHARS = (('a'..'z').to_a + ('0'..'9').to_a)
-      IAL_RAND_STRING = (1..20).collect {|a| IAL_RAND_CHARS[rand(IAL_RAND_CHARS.size)]}.join
+      IAL_RAND_STRING = (1..20).collect { IAL_RAND_CHARS[rand(IAL_RAND_CHARS.size)] }.join
       LIST_ITEM_IAL = /^\s*(#{IAL_RAND_STRING})?\s*\n/
       IAL_SPAN_START = LIST_ITEM_IAL
 

--- a/setup.rb
+++ b/setup.rb
@@ -886,7 +886,7 @@ class ToplevelInstaller
   end
 
   def valid_task_re
-    @valid_task_re ||= /\A(?:#{TASKS.map {|task,desc| task }.join('|')})\z/
+    @valid_task_re ||= /\A(?:#{TASKS.map {|task,_desc| task }.join('|')})\z/
   end
 
   def parsearg_no_options


### PR DESCRIPTION
By using appropriate alternate methods or prefixing the unused parameter with an underscore (`_`)