### PR TITLE
Simplify PARAGRAPH_END_GFM regex with Regexp.union

### DIFF
--- a/lib/kramdown/parser/gfm.rb
+++ b/lib/kramdown/parser/gfm.rb
@@ -177,7 +177,17 @@ module Kramdown
       ESCAPED_CHARS_GFM = /\\([\\.*_+`<>()\[\]{}#!:\|"'\$=\-~])/
       define_parser(:escaped_chars_gfm, ESCAPED_CHARS_GFM, '\\\\', :parse_escaped_chars)
 
-      PARAGRAPH_END_GFM = /#{LAZY_END}|#{LIST_START}|#{ATX_HEADER_START}|#{DEFINITION_LIST_START}|#{BLOCKQUOTE_START}|#{FENCED_CODEBLOCK_START}/
+      # Equivalent to:
+      # /#{LAZY_END}|#{LIST_START}|#{ATX_HEADER_START}|#{DEFINITION_LIST_START}|#{BLOCKQUOTE_START}|#{FENCED_CODEBLOCK_START}/
+      #
+      PARAGRAPH_END_GFM = Regexp.union(
+        LAZY_END,
+        LIST_START,
+        ATX_HEADER_START,
+        DEFINITION_LIST_START,
+        BLOCKQUOTE_START,
+        FENCED_CODEBLOCK_START
+      ).freeze
 
       def paragraph_end
         @paragraph_end


### PR DESCRIPTION
The intention here is to improve readability by:
  - reducing line-length
  - removing distracting curly braces