### PR TITLE
Improve inspect string for Kramdown::Element

### DIFF
--- a/lib/kramdown/element.rb
+++ b/lib/kramdown/element.rb
@@ -501,7 +501,12 @@ module Kramdown
     end
 
     def inspect #:nodoc:
-      "<kd:#{@type}#{@value.nil? ? '' : ' ' + @value.inspect} #{@attr.inspect}#{options.empty? ? '' : ' ' + @options.inspect}#{@children.empty? ? '' : ' ' + @children.inspect}>"
+      str = +"<kd:#{@type}"
+      str << " value=#{@value.inspect}"       if !@value.nil?    && !@value.empty?
+      str << " attr=#{@attr.inspect}"         if !@attr.nil?     && !@attr.empty?
+      str << " options=#{@options.inspect}"   if !@options.nil?  && !@options.empty?
+      str << " children=#{@children.inspect}" if !@children.nil? && !@children.empty?
+      str << ">"
     end
 
     CATEGORY = {} # :nodoc:


### PR DESCRIPTION
Currently on `master`, inspecting the `@root` from `Kramdown::Parser::Base` outputs:
```
<kd:root nil {:encoding=>#<Encoding:UTF-8>, :location=>1, :options=>{}, :abbrev_defs=>{}, :abbrev_attr=>{}}>
```
The output string doesn't really help identifying the provided values.

With the proposed change, the same output  becomes:
```
<kd:root options={:encoding=>#<Encoding:UTF-8>, :location=>1, :options=>{}, :abbrev_defs=>{}, :abbrev_attr=>{}}>
```
and if `@root` was inspected later in the session, the output would become:
```
<kd:root options={:encoding=>#<Encoding:UTF-8>, :location=>1, :options=>{}, :abbrev_defs=>{}, :abbrev_attr=>{}} children=[<kd:text value="First line of a paragraph.\n" options={:location=>1}>]>
```