### PR TITLE
Enable Rouge plaintext lexer with :guess_lang opt

### DIFF
--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -25,8 +25,11 @@ module Kramdown::Converter::SyntaxHighlighter
       opts = options(converter, type)
       call_opts[:default_lang] = opts[:default_lang]
       return nil unless lang || opts[:default_lang] || opts[:guess_lang]
+
       lexer = ::Rouge::Lexer.find_fancy(lang || opts[:default_lang], text)
-      return nil if opts[:disable] || !lexer || lexer.tag == "plaintext"
+      return nil if opts[:disable] || !lexer
+      return nil if lexer.tag == "plaintext" && !opts[:guess_lang]
+
       opts[:css_class] ||= 'highlight' # For backward compatibility when using Rouge 2.0
       formatter = formatter_class(opts).new(opts)
       formatter.format(lexer.lex(text))

--- a/test/testcases/block/06_codeblock/guess_lang_css_class.html
+++ b/test/testcases/block/06_codeblock/guess_lang_css_class.html
@@ -1,0 +1,15 @@
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>class Foo
+  def bar
+    puts 'Hello'
+  end
+end
+</code></pre>
+</div></div>
+
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>class Foo
+  def bar
+    puts 'Hello'
+  end
+end
+</code></pre>
+</div></div>

--- a/test/testcases/block/06_codeblock/guess_lang_css_class.options
+++ b/test/testcases/block/06_codeblock/guess_lang_css_class.options
@@ -1,0 +1,2 @@
+:syntax_highlighter_opts:
+  guess_lang: true

--- a/test/testcases/block/06_codeblock/guess_lang_css_class.text
+++ b/test/testcases/block/06_codeblock/guess_lang_css_class.text
@@ -1,0 +1,13 @@
+~~~
+class Foo
+  def bar
+    puts 'Hello'
+  end
+end
+~~~
+
+    class Foo
+      def bar
+        puts 'Hello'
+      end
+    end

--- a/test/testcases/span/03_codespan/normal-css-class.html
+++ b/test/testcases/span/03_codespan/normal-css-class.html
@@ -1,0 +1,1 @@
+<p>This is a <code class="highlighter-rouge">code-span</code></p>

--- a/test/testcases/span/03_codespan/normal-css-class.options
+++ b/test/testcases/span/03_codespan/normal-css-class.options
@@ -1,0 +1,2 @@
+:syntax_highlighter_opts:
+  guess_lang: true

--- a/test/testcases/span/03_codespan/normal-css-class.text
+++ b/test/testcases/span/03_codespan/normal-css-class.text
@@ -1,0 +1,1 @@
+This is a `code-span`


### PR DESCRIPTION
Utilize `:guess_lang` highlighter-option from kramdown-2.0 to enable Rouge's plaintext lexer
(This avoids having to maintain multiple options for same result)

Resolves #572 