### PR TITLE
Add math_engine without iteration

### DIFF
--- a/lib/kramdown/converter.rb
+++ b/lib/kramdown/converter.rb
@@ -49,18 +49,15 @@ module Kramdown
 
     configurable(:math_engine)
 
-    ["Mathjax"].each do |klass_name|
-      kn_down = klass_name.downcase.intern
-      add_math_engine(kn_down) do |converter, el, opts|
-        require "kramdown/converter/math_engine/#{kn_down}"
-        klass = ::Kramdown::Utils.deep_const_get("::Kramdown::Converter::MathEngine::#{klass_name}")
-        if !klass.const_defined?(:AVAILABLE) || klass::AVAILABLE
-          add_math_engine(kn_down, klass)
-        else
-          add_math_engine(kn_down) { nil }
-        end
-        math_engine(kn_down).call(converter, el, opts)
+    add_math_engine(:mathjax) do |converter, el, opts|
+      require "kramdown/converter/math_engine/mathjax"
+      klass = ::Kramdown::Converter::MathEngine::Mathjax
+      if !klass.const_defined?(:AVAILABLE) || klass::AVAILABLE
+        add_math_engine(:mathjax, klass)
+      else
+        add_math_engine(:mathjax) { nil }
       end
+      math_engine(:mathjax).call(converter, el, opts)
     end
 
   end


### PR DESCRIPTION
This removes some redundancy with adding the lone `math_engine` in kramdown core: `Mathjax`

## Motivations
- It appears wasteful to iterate through a ***known** single-item array* and then referring to that single-item in the associated block. (allocation for array, allocation for block parameter)
- Unnecessary allocation for a local variable to hold a Symbol with a known name.
- Unnecessary interpolations for a known string.

## Advantages
- Addresses the motivation listed above
- Absence of interpolation allows the resulting string to be frozen automatically.
- Absence of interpolation allows removing the now redundant use of `Kramdown::Utils.deep_const_get()`

## Disadvantages
- Makes addition of new `math_engine` to *kramdown core* harder.
