### PR TITLE
[WIP] Initialize Kramdown::Element with better defaults

### DIFF
--- a/lib/kramdown/element.rb
+++ b/lib/kramdown/element.rb
@@ -485,7 +485,7 @@ module Kramdown
 
     # Create a new Element object of type +type+. The optional parameters +value+, +attr+ and
     # +options+ can also be set in this constructor for convenience.
-    def initialize(type, value = nil, attr = nil, options = nil)
+    def initialize(type, value = nil, attr = {}, options = {})
       @type, @value, @attr, @options = type, value, attr, options
       @children = []
     end


### PR DESCRIPTION
Since `@attr` and `@options` will eventually be set to `{}` via getters `#attr` and `#options`. I feel it would be better if `Element` objects were initialized with those value from the outset.

While this change won't have any visible effect because *majority of the `Element` objects* are currently initialized with `nil` as explicit arguments for these parameters, I can push commits making related changes to the constructor calls across the library if @gettalong is fine with this approach.

*P. S.: Re-enabling Travis CI would help with this..*