### PR TITLE
Ask an element if it is a :block or :span directly

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -34,13 +34,13 @@ module Kramdown
         res = res.dup if res.frozen?
         if ![:html_element, :li, :dt, :dd, :td].include?(el.type) && (ial = ial_for_element(el))
           res << ial
-          res << "\n\n" if Element.category(el) == :block
+          res << "\n\n" if el.block?
         elsif [:ul, :dl, :ol, :codeblock].include?(el.type) && opts[:next] &&
             ([el.type, :codeblock].include?(opts[:next].type) ||
              (opts[:next].type == :blank && opts[:nnext] &&
               [el.type, :codeblock].include?(opts[:nnext].type)))
           res << "^\n\n"
-        elsif Element.category(el) == :block &&
+        elsif el.block? &&
             ![:li, :dd, :dt, :td, :th, :tr, :thead, :tbody, :tfoot, :blank].include?(el.type) &&
             (el.type != :html_element || @stack.last.type != :html_element) &&
             (el.type != :p || !el.options[:transparent])
@@ -187,7 +187,7 @@ module Kramdown
       def convert_html_element(el, opts)
         markdown_attr = el.options[:category] == :block && el.children.any? do |c|
           c.type != :html_element && (c.type != :p || !c.options[:transparent]) &&
-            Element.category(c) == :block
+            c.block?
         end
         opts[:force_raw_text] = true if %w[script pre code].include?(el.value)
         opts[:raw_text] = opts[:force_raw_text] || opts[:block_raw_text] || \

--- a/lib/kramdown/element.rb
+++ b/lib/kramdown/element.rb
@@ -522,6 +522,22 @@ module Kramdown
       CATEGORY[el.type] || el.options[:category]
     end
 
+    # syntactic sugar to simplify calls such as +Kramdown::Element.category(el) == :block+ with
+    # +el.block?+.
+    #
+    # Returns boolean true or false.
+    def block?
+      (CATEGORY[type] || options[:category]) == :block
+    end
+
+    # syntactic sugar to simplify calls such as +Kramdown::Element.category(el) == :span+ with
+    # +el.span?+.
+    #
+    # Returns boolean true or false.
+    def span?
+      (CATEGORY[type] || options[:category]) == :span
+    end
+
   end
 
 end

--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -324,7 +324,7 @@ module Kramdown
           tmp = []
           last_is_p = false
           el.children.each do |c|
-            if Element.category(c) != :block || c.type == :text
+            if !c.block? || c.type == :text
               unless last_is_p
                 tmp << Element.new(:p, nil, nil, transparent: true)
                 last_is_p = true
@@ -354,8 +354,8 @@ module Kramdown
           el.children = el.children.reject do |c|
             i += 1
             c.type == :text && c.value.strip.empty? &&
-              (i == 0 || i == el.children.length - 1 || (Element.category(el.children[i - 1]) == :block &&
-                                                         Element.category(el.children[i + 1]) == :block))
+              (i == 0 || i == el.children.length - 1 || ((el.children[i - 1]).block? &&
+                                                         (el.children[i + 1]).block?))
           end
         end
 


### PR DESCRIPTION
Allows simplifying calls such as `Kramdown::Element.category(el) == :block` or
`Kramdown::Element.category(el) == :span` with **`el.block?`** and **`el.span?`** respectively.