### PR TITLE
Use static regex for simple codespan results

### DIFF
--- a/lib/kramdown/parser/kramdown/codespan.rb
+++ b/lib/kramdown/parser/kramdown/codespan.rb
@@ -27,16 +27,10 @@ module Kramdown
 
         # assign static regex to avoid allocating the same on every instance
         # where +result+ equals a single-backtick. Interpolate otherwise.
-        if result == '`'
-          scan_pattern = /`/
-          str_sub_pattern = /`\Z/
-        else
-          scan_pattern = /#{result}/
-          str_sub_pattern = /#{result}\Z/
-        end
+        scan_pattern = (result == '`') ? /`/ : /#{result}/
 
         if (text = @src.scan_until(scan_pattern))
-          text.sub!(str_sub_pattern, '')
+          text.chomp!(result)
           unless simple
             text = text[1..-1] if text[0..0] == ' '
             text = text[0..-2] if text[-1..-1] == ' '

--- a/lib/kramdown/parser/kramdown/codespan.rb
+++ b/lib/kramdown/parser/kramdown/codespan.rb
@@ -25,8 +25,18 @@ module Kramdown
           return
         end
 
-        if (text = @src.scan_until(/#{result}/))
-          text.sub!(/#{result}\Z/, '')
+        # assign static regex to avoid allocating the same on every instance
+        # where +result+ equals a single-backtick. Interpolate otherwise.
+        if result == '`'
+          scan_pattern = /`/
+          str_sub_pattern = /`\Z/
+        else
+          scan_pattern = /#{result}/
+          str_sub_pattern = /#{result}\Z/
+        end
+
+        if (text = @src.scan_until(scan_pattern))
+          text.sub!(str_sub_pattern, '')
           unless simple
             text = text[1..-1] if text[0..0] == ' '
             text = text[0..-2] if text[-1..-1] == ' '

--- a/lib/kramdown/parser/kramdown/codespan.rb
+++ b/lib/kramdown/parser/kramdown/codespan.rb
@@ -27,10 +27,16 @@ module Kramdown
 
         # assign static regex to avoid allocating the same on every instance
         # where +result+ equals a single-backtick. Interpolate otherwise.
-        scan_pattern = (result == '`') ? /`/ : /#{result}/
+        if result == '`'
+          scan_pattern = /`/
+          str_sub_pattern = /`\Z/
+        else
+          scan_pattern = /#{result}/
+          str_sub_pattern = /#{result}\Z/
+        end
 
         if (text = @src.scan_until(scan_pattern))
-          text.chomp!(result)
+          text.sub!(str_sub_pattern, '')
           unless simple
             text = text[1..-1] if text[0..0] == ' '
             text = text[0..-2] if text[-1..-1] == ' '


### PR DESCRIPTION
## Rationale

It is wasteful to allocate <code>/\`/</code> and <code>/\`\Z/</code> every time a simple codespan is parsed. Instead use a static regex which is allocated only once each.

## Context
Results from profiling Jekyll docs:

### Before
```
Total allocated: 158.07 MB (1168216 objects)
Total retained:  10.3 MB (92547 objects)
```
### After
```
Total allocated: 157.1 MB (1162835 objects)
Total retained:  10.3 MB (92547 objects)
```
