### PR TITLE
Use constants to return valid smart-quotes values

### DIFF
--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -377,7 +377,11 @@ module Kramdown
       simple_array_validator(val, :latex_headers, 6)
     end
 
-    define(:smart_quotes, Object, %w[lsquo rsquo ldquo rdquo], <<~EOF) do |val|
+    SMART_QUOTES_ENTITIES = %w[lsquo rsquo ldquo rdquo].freeze
+    SMART_QUOTES_STR = SMART_QUOTES_ENTITIES.join(',').freeze
+    private_constant :SMART_QUOTES_ENTITIES, :SMART_QUOTES_STR
+
+    define(:smart_quotes, Object, SMART_QUOTES_ENTITIES, <<~EOF) do |val|
       Defines the HTML entity names or code points for smart quote output
 
       The entities identified by entity name or code point that should be
@@ -388,9 +392,13 @@ module Kramdown
       Default: lsquo,rsquo,ldquo,rdquo
       Used by: HTML/Latex converter
     EOF
-      val = simple_array_validator(val, :smart_quotes, 4)
-      val.map! {|v| Integer(v) rescue v }
-      val
+      if val == SMART_QUOTES_STR || val == SMART_QUOTES_ENTITIES
+        SMART_QUOTES_ENTITIES
+      else
+        val = simple_array_validator(val, :smart_quotes, 4)
+        val.map! {|v| Integer(v) rescue v }
+        val
+      end
     end
 
     define(:typographic_symbols, Object, {}, <<~EOF) do |val|


### PR DESCRIPTION
This is helpful for downstream libraries such as Jekyll where a single configuration is used to process numerous kramdown documents.

To illustrate, consider the following flow:
```ruby
# given: `documents` is an array of 1000 Markdown pages

kd_opts = {:smart_quotes => "lsquo,rsquo,ldquo,rdquo"}
outbox  = documents.map { |doc| Kramdown::Document.new(doc.content. kd_opts).to_html }
```
By running the above script, there's going to be a 1000 instances of `Kramdown::Document` (obviously).
But each of those instance is going to use the same set of `options`.

However, each of those instance is going to allocate a new `%w[lsquo rsquo ldquo rdquo]` via `val.split(/,/)` during the validation. The arrays so obtained are valid but in spite of that, each constituent element is consequently forced to initialize an `ArgumentError` via `Kernel#Integer` and then fallback to returning original *element*.

---

- The proposed solution is therefore to define a constant and tally given option value against it. If the two objects are *equal in both the size and order of elements*, return the given value otherwise, proceed to existing logic.
 - I added another constant to similarly optimize situations where the option was a *valid array* in the first place (instead of the default csv).

Attn: @gettalong 

P.S. Additionally, the `else` block could be optimized to not rescue an intermediate exception, but I chose to defer that for future.