### PR TITLE
Interpolate stateless regexps just once

### DIFF
--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -286,7 +286,7 @@ module Kramdown
           src = Kramdown::Utils::StringScanner.new(raw)
           result = []
           until src.eos?
-            if (tmp = src.scan_until(/(?=#{HTML_ENTITY_RE})/))
+            if (tmp = src.scan_until(/(?=#{HTML_ENTITY_RE})/o))
               result << Element.new(:text, tmp)
               src.scan(HTML_ENTITY_RE)
               val = src[1] || (src[2]&.to_i) || src[3].hex
@@ -581,11 +581,11 @@ module Kramdown
         @src = Kramdown::Utils::StringScanner.new(adapt_source(source))
 
         while true
-          if (result = @src.scan(/\s*#{HTML_INSTRUCTION_RE}/))
+          if (result = @src.scan(/\s*#{HTML_INSTRUCTION_RE}/o))
             @tree.children << Element.new(:xml_pi, result.strip, nil, category: :block)
-          elsif (result = @src.scan(/\s*#{HTML_DOCTYPE_RE}/))
+          elsif (result = @src.scan(/\s*#{HTML_DOCTYPE_RE}/o))
             # ignore the doctype
-          elsif (result = @src.scan(/\s*#{HTML_COMMENT_RE}/))
+          elsif (result = @src.scan(/\s*#{HTML_COMMENT_RE}/o))
             @tree.children << Element.new(:xml_comment, result.strip, nil, category: :block)
           else
             break

--- a/lib/kramdown/parser/kramdown/html.rb
+++ b/lib/kramdown/parser/kramdown/html.rb
@@ -79,12 +79,12 @@ module Kramdown
           @src.scan(TRAILING_WHITESPACE)
           true
         else
-          if @src.check(/^#{OPT_SPACE}#{HTML_TAG_RE}/) && !HTML_SPAN_ELEMENTS.include?(@src[1].downcase)
+          if @src.check(/^#{OPT_SPACE}#{HTML_TAG_RE}/o) && !HTML_SPAN_ELEMENTS.include?(@src[1].downcase)
             @src.pos += @src.matched_size
             handle_html_start_tag(line, &method(:handle_kramdown_html_tag))
             Kramdown::Parser::Html::ElementConverter.convert(@root, @tree.children.last) if @options[:html_to_native]
             true
-          elsif @src.check(/^#{OPT_SPACE}#{HTML_TAG_CLOSE_RE}/) && !HTML_SPAN_ELEMENTS.include?(@src[1].downcase)
+          elsif @src.check(/^#{OPT_SPACE}#{HTML_TAG_CLOSE_RE}/o) && !HTML_SPAN_ELEMENTS.include?(@src[1].downcase)
             name = @src[1].downcase
 
             if @tree.type == :html_element && @tree.value == name

--- a/lib/kramdown/parser/kramdown/math.rb
+++ b/lib/kramdown/parser/kramdown/math.rb
@@ -21,7 +21,7 @@ module Kramdown
         if !after_block_boundary?
           return false
         elsif @src[1]
-          @src.scan(/^#{OPT_SPACE}\\/) if @src[3]
+          @src.scan(/^#{OPT_SPACE}\\/o) if @src[3]
           return false
         end
 

--- a/lib/kramdown/parser/kramdown/table.rb
+++ b/lib/kramdown/parser/kramdown/table.rb
@@ -132,8 +132,8 @@ module Kramdown
               pipe_on_line = false
             end
           else
-            break if lines.size > 1 && !pipe_on_line && lines.first !~ /^#{TABLE_PIPE_CHECK}/
-            pipe_on_line = (lines.size > 1 ? false : pipe_on_line) || (lines.last =~ /^#{TABLE_PIPE_CHECK}/)
+            break if lines.size > 1 && !pipe_on_line && lines.first !~ /^#{TABLE_PIPE_CHECK}/o
+            pipe_on_line = (lines.size > 1 ? false : pipe_on_line) || (lines.last =~ /^#{TABLE_PIPE_CHECK}/o)
           end
         end
         @src.revert_pos(saved_pos) and return false unless pipe_on_line


### PR DESCRIPTION
If an interpolated regular expression within a method definition and if the interpolation doesn't depend on the state of the instance, then they should essentially be **interpolated just once** to avoid multiple allocations and every call to the associated method.