### PR TITLE
Try requiring file only if not loaded already

### DIFF
--- a/lib/kramdown/document.rb
+++ b/lib/kramdown/document.rb
@@ -127,9 +127,11 @@ module Kramdown
 
     # Try requiring a parser or converter class and don't raise an error if the file is not found.
     def try_require(type, name)
-      require("kramdown/#{type}/#{Utils.snake_case(name)}")
+      unless Kramdown.const_get(type.capitalize, false).const_defined?(name)
+        require "kramdown/#{type}/#{Utils.snake_case(name)}"
+      end
       true
-    rescue LoadError
+    rescue LoadError, NameError
       true
     end
     protected :try_require


### PR DESCRIPTION
The goal here is to reduce unnecessary allocations from interpolated strings.

If a 100 `Kramdown::Document` objects are being parsed and converted by the same parser and converter classes (e.g, `Parser::Kramdown` and `Converter::Kramdown`), then there's no point in allocating a 100 `kramdown/parser/kramdown` and `kramdown/converter/kramdown` strings only to be thrown away immediately since `require` is going to load the path just once.

`NameError` is rescued in case `Kramdown.const_get(type.capitalize, false)` results in an uninitialized constant lookup.