### PR TITLE
Add rake task to profile memory usage of testcases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,14 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-  - 2.6
+  - &latest_ruby 2.6
   - jruby-head
 
 matrix:
+  include:
+    - rvm: *latest_ruby
+      script: rake dev:profile_memory
+      name: Profile Memory Usage
   allow_failures:
     - rvm: jruby-head
 
@@ -20,11 +24,9 @@ addons:
       - texlive-latex-extra
 
 before_install:
-  - gem install rake
-  - gem install minitest stringex
-  - gem install rouge
   - wget https://github.com/htacg/tidy-html5/releases/download/5.4.0/tidy-5.4.0-64bit.deb
   - sudo apt purge libtidy-0.99-0
   - sudo dpkg -i tidy-5.4.0-64bit.deb
 
+install: gem install memory_profiler minitest rake rouge stringex
 script: ruby -Ilib:test test/test_*

--- a/Rakefile
+++ b/Rakefile
@@ -215,6 +215,12 @@ namespace :dev do
     end
   end
 
+  desc "Profile memory usage from the test-cases"
+  task :profile_memory do
+    puts ""
+    ruby 'benchmark/profile_memory_usage.rb'
+  end
+
   desc "Upload the website"
   task publish_website: ['doc'] do
     puts "Transfer manually!!!"

--- a/benchmark/profile_memory_usage.rb
+++ b/benchmark/profile_memory_usage.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.join(__dir__, '../lib')
+
+require 'kramdown'
+require 'memory_profiler'
+require 'minitest'
+require 'rouge'
+
+class Rouge::Formatters::HTMLLegacy
+  def format(tokens, &b)
+    super(tokens, &b).sub(/<\/code><\/pre>\n?/, "</code></pre>\n")
+  end
+end
+
+class RougeHTMLFormatters < Rouge::Formatters::HTMLLegacy
+  def stream(tokens, &b)
+    yield '<div class="custom-class">'
+    super
+    yield '</div>'
+  end
+end
+
+Encoding.default_external = 'utf-8'
+
+class KdProfiler
+  include Minitest::Assertions
+  attr_accessor :assertions
+
+  DEFAULT_OPTS = { auto_ids: false, footnote_nr: 1 }
+
+  def initialize
+    @assertions = 0
+  end
+
+  def assert_test_cases
+    Dir[File.join(__dir__, '../test/testcases/**/*.text')].each do |text_file|
+      basename  = text_file.sub(/\.text$/, '')
+      opts_file = text_file.sub(/\.text$/, '.options')
+
+      (Dir[basename + ".*"] - [text_file, opts_file]).each do |output_file|
+        output_format = File.extname(output_file)[1..-1]
+        next unless Kramdown::Converter.const_defined?(output_format.capitalize)
+
+        opts_file = File.join(File.dirname(text_file), 'options') unless File.exist?(opts_file)
+        options   = File.exist?(opts_file) ? YAML.load(File.read(opts_file)) : DEFAULT_OPTS
+
+        result = Kramdown::Document.new(File.read(text_file), options).send("to_#{output_format}")
+        assert_equal result, File.read(output_file)
+      end
+    end
+  end
+end
+
+start = Time.now
+print "\nProfiling... "
+
+report = MemoryProfiler.report(allow_files: 'kramdown') { KdProfiler.new.assert_test_cases }
+puts "Done in #{(Time.now - start).round(2)} seconds."
+puts "Generating results.."
+puts
+
+print_opts = {scale_bytes: true}
+
+unless ENV['CI']
+  total_allocated_output = report.scale_bytes(report.total_allocated_memsize)
+  total_retained_output  = report.scale_bytes(report.total_retained_memsize)
+
+  puts "-" * 50
+  puts "Total allocated: #{total_allocated_output} (#{report.total_allocated} objects)"
+  puts "Total retained:  #{total_retained_output} (#{report.total_retained} objects)"
+  puts "-" * 50
+
+  report_file = '.memprof.tmp'
+  print_opts.merge!(to_file: report_file)
+  puts "\nDetailed report saved to '#{report_file}'"
+end
+report.pretty_print(print_opts)


### PR DESCRIPTION
This RakeTask runs assertions on the `testcases/` files, profiles memory usage and prints out the memory usage stats (to a file locally and to `stdout` on CI)
(*Additionally, Travis CI has been configured to run this task should you decide to re-enable it for this repo.*)