### PR TITLE
Fix formatting in syntax documentation

### DIFF
--- a/doc/syntax.page
+++ b/doc/syntax.page
@@ -1535,7 +1535,7 @@ kramdown converts the following plain ASCII character into their corresponding t
   non-breakable space
 
 The parser also replaces normal single `'` and double quotes `"` with "fancy quotes". There *may* be
-times when kramdown falsely replace the quotes. If this is the case, just \'escape\" the quotes and
+times when kramdown falsely replace the quotes. If this is the case, just `\'escape\"` the quotes and
 they won't be replaced with fancy ones.
 
 


### PR DESCRIPTION
Put the example that shows how quotes can be escaped with backslashes
inside a code span to display the backslashes.