### PR TITLE
Update memprof_preload script to improve local use

### DIFF
--- a/benchmark/memory_profiler_preload.rb
+++ b/benchmark/memory_profiler_preload.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 BEGIN {
   require 'memory_profiler'
   start = Time.now
-  print "\nProfiling... "
+  puts "\nProfiling...\n\n"
 
   MemoryProfiler.start(allow_files: 'kramdown')
 }
@@ -9,7 +11,7 @@ BEGIN {
 END {
   report = MemoryProfiler.stop
 
-  puts "Done in #{(Time.now - start).round(2)} seconds."
+  puts "\nDone in #{(Time.now - start).round(2)} seconds."
   puts "Generating results.."
   puts
 
@@ -30,5 +32,3 @@ END {
   end
   report.pretty_print(print_opts)
 }
-
-


### PR DESCRIPTION
- Add `frozen_string_literal` pragma
- Remove extra trailing blank lines
- Adjust log output to accommodate messages received from *the tested script.*