### PR TITLE
Fix a bug that kept us from adding the markdown attribute to HTML tags that contain valid markdown when parsing HTML

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -184,10 +184,14 @@ module Kramdown
 
       HTML_TAGS_WITH_BODY = ['div', 'script', 'iframe', 'textarea']
 
+      NON_MARKDOWN_TYPES = [:entity, :text, :html_element].freeze
+      private_constant :NON_MARKDOWN_TYPES
+
       def convert_html_element(el, opts)
         markdown_attr = el.options[:category] == :block && el.children.any? do |c|
-          c.type != :html_element && (c.type != :p || !c.options[:transparent]) &&
-            Element.category(c) == :block
+          c.type != :html_element &&
+          !(c.type == :p && c.options[:transparent] && c.children.none? { |t| !NON_MARKDOWN_TYPES.member?(t.type) }) &&
+          Element.category(c) == :block
         end
         opts[:force_raw_text] = true if %w[script pre code].include?(el.value)
         opts[:raw_text] = opts[:force_raw_text] || opts[:block_raw_text] || \

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -180,6 +180,7 @@ class TestFiles < Minitest::Test
       'test/testcases/block/09_html/xml.text', # bc of tidy
       'test/testcases/span/05_html/xml.text', # bc of tidy
       'test/testcases/block/03_paragraph/standalone_image.text', # bc of standalone image
+      'test/testcases/block/09_html/standalone_image_in_div.html', # bc of standalone image
     ].compact
     Dir[File.dirname(__FILE__) + '/testcases/**/*.text'].each do |text_file|
       next if EXCLUDE_TEXT_FILES.any? {|f| text_file =~ /#{f}$/ }
@@ -230,6 +231,7 @@ class TestFiles < Minitest::Test
       'test/testcases/block/09_html/xml.html', # bc of tidy
       'test/testcases/span/05_html/xml.html', # bc of tidy
       'test/testcases/block/03_paragraph/standalone_image.html', # bc of standalone image
+      'test/testcases/block/09_html/standalone_image_in_div.html', # bc of standalone image
     ].compact
     Dir[File.dirname(__FILE__) + '/testcases/**/*.html'].each do |html_file|
       next if EXCLUDE_HTML_KD_FILES.any? {|f| html_file =~ /#{f}$/ }

--- a/test/testcases/block/09_html/standalone_image_in_div.htmlinput
+++ b/test/testcases/block/09_html/standalone_image_in_div.htmlinput
@@ -1,0 +1,7 @@
+<div class="example-1">
+  <img src="src.png" alt="inside" />
+</div>
+
+<div class="example-2">
+  <a href="website.html">text</a>
+</div>

--- a/test/testcases/block/09_html/standalone_image_in_div.text
+++ b/test/testcases/block/09_html/standalone_image_in_div.text
@@ -1,0 +1,8 @@
+<div class="example-1" markdown="1">
+![inside](src.png)
+</div>
+
+<div class="example-2" markdown="1">
+[text](website.html)
+</div>
+


### PR DESCRIPTION
You can reproduce the bug like this:

> ```ruby
> html = <<~HTML
> <div>
>   <img src="src.png" alt="alt" />
> </div>
> HTML
> 
> markdown = Kramdown::Document.new(html, input: :html).to_kramdown
> # => "<div>\n![alt](src.png)\n</div>"
> 
> html = Kramdown::Document.new(markdown).to_html
> # => "<div>\n![alt](src.png)\n</div>\n\n"
> ```

The bug is that the call to `to_kramdown` converted the IMG tag but **_did not_** add `markdown="1"` to the DIV tag.

As of Kramdown 2.1.0, the `markdown` attribute is added if the IMG tag is wrapped in a paragraph; and you can see that when the `markdown` attribute is present, the HTML roundtrips successfully:

> ```ruby
> html = <<~HTML
> <div>
>   <p><img src="src.png" alt="alt" /></p>
> </div>
> HTML
> 
> markdown = Kramdown::Document.new(html, input: :html).to_kramdown
> # => "<div markdown=\"1\">\n![alt](src.png)\n</div>"
> 
> html = Kramdown::Document.new(markdown).to_html
> # => "<div>\n  <p><img src=\"src.png\" alt=\"alt\" /></p>\n\n</div>"
> ```