### PR TITLE
Reduce string allocations from adapting source

### DIFF
--- a/lib/kramdown/parser/base.rb
+++ b/lib/kramdown/parser/base.rb
@@ -93,7 +93,9 @@ module Kramdown
           raise "The source text contains invalid characters for the used encoding #{source.encoding}"
         end
         source = source.encode('UTF-8')
-        source.gsub(/\r\n?/, "\n").chomp + "\n"
+        source.gsub!(/\r\n?/, "\n")
+        source.chomp!
+        source << "\n"
       end
 
       # This helper method adds the given +text+ either to the last element in the +tree+ if it is a


### PR DESCRIPTION
`String#encode` returns a copy of the given `source` string.
Subsequent operations on this copy can be made in place to avoid allocating intermediate strings.