### PR TITLE
Allow juxtaposing `&[mn]dash;` and emphasis

### DIFF
--- a/lib/kramdown/parser/kramdown/emphasis.rb
+++ b/lib/kramdown/parser/kramdown/emphasis.rb
@@ -22,7 +22,7 @@ module Kramdown
         element = (result.length == 2 ? :strong : :em)
         type = result[0..0]
 
-        if (type == '_' && @src.pre_match =~ /[[:alpha:]-]\z/) || @src.check(/\s/) ||
+        if (type == '_' && @src.pre_match =~ /[[:alpha:]]-?[[:alpha:]]*\z/) || @src.check(/\s/) ||
             @tree.type == element || @stack.any? {|el, _| el.type == element }
           add_text(result)
           return

--- a/test/testcases/span/02_emphasis/normal.html
+++ b/test/testcases/span/02_emphasis/normal.html
@@ -59,3 +59,7 @@ Or that *<em>that*</em> way</p>
   <li>`<em>test</em>&#8217;</li>
   <li>„<em>test</em>“</li>
 </ul>
+
+<p>it&#8211;by design&#8211;<em>cannot have side-effects</em>.</p>
+
+<p>it&#8212;by design&#8212;<em>cannot have side-effects</em>.</p>

--- a/test/testcases/span/02_emphasis/normal.text
+++ b/test/testcases/span/02_emphasis/normal.text
@@ -57,3 +57,7 @@ Or that \**that\** way
 - “_test_”
 - \`_test_'
 - „_test_“
+
+it--by design--_cannot have side-effects_.
+
+it---by design---_cannot have side-effects_.


### PR DESCRIPTION
Resolves #624 

/cc @codingthat