### PR TITLE
s/a HTML/an HTML/ in documents

### DIFF
--- a/doc/syntax.page
+++ b/doc/syntax.page
@@ -1078,7 +1078,7 @@ Parse as span-level elements
         h1 h2 h3 h4 h5 h6 i ins kbd label legend optgroup p pre q rb rbc
         rp rt rtc ruby samp select small span strong sub sup th tt var
 
-> Remember that all span-level HTML tags like `a` or `b` do not start a HTML block! However, the
+> Remember that all span-level HTML tags like `a` or `b` do not start an HTML block! However, the
 > above lists also include span-level HTML tags in the case the `markdown` attribute is used on a
 > tag inside a raw HTML block.
 

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -480,7 +480,7 @@ module Kramdown
 
       FOOTNOTE_BACKLINK_FMT = "%s<a href=\"#fnref:%s\" class=\"reversefootnote\">%s</a>"
 
-      # Return a HTML ordered list with the footnote content for the used footnotes.
+      # Return an HTML ordered list with the footnote content for the used footnotes.
       def footnote_content
         ol = Element.new(:ol)
         ol.attr['start'] = @footnote_start if @footnote_start != 1

--- a/lib/kramdown/converter/syntax_highlighter.rb
+++ b/lib/kramdown/converter/syntax_highlighter.rb
@@ -42,7 +42,7 @@ module Kramdown
     #
     # == Special Implementation Details
     #
-    # HTML converter:: If the syntax highlighter is used with a HTML converter, it should return
+    # HTML converter:: If the syntax highlighter is used with an HTML converter, it should return
     #                  :block type text correctly wrapped (i.e. normally inside a pre-tag, but may
     #                  also be a table-tag or just a div-tag) but :span type text *without* a
     #                  code-tag!

--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -16,7 +16,7 @@ module Kramdown
 
   module Parser
 
-    # Used for parsing a HTML document.
+    # Used for parsing an HTML document.
     #
     # The parsing code is in the Parser module that can also be used by other parsers.
     class Html < Base


### PR DESCRIPTION
I found a typo in syntax page.
https://kramdown.gettalong.org/syntax.html

I fixed it and all same others.