### PR TITLE
Add "start" attribute to <ol> for HTML conversion

### DIFF
--- a/lib/kramdown/parser/kramdown/list.rb
+++ b/lib/kramdown/parser/kramdown/list.rb
@@ -47,6 +47,7 @@ module Kramdown
       LIST_START_UL = /^(#{OPT_SPACE}[+*-])([\t| ].*?\n)/
       LIST_START_OL = /^(#{OPT_SPACE}\d+\.)([\t| ].*?\n)/
       LIST_START = /#{LIST_START_UL}|#{LIST_START_OL}/
+      LIST_START_NUM_OL = /^#{OPT_SPACE}(\d)+\./
 
       # Parse the ordered or unordered list at the current location.
       def parse_list
@@ -59,6 +60,7 @@ module Kramdown
         eob_found = false
         nested_list_found = false
         last_is_blank = false
+	list_first = true
         until @src.eos?
           start_line_number = @src.current_line_number
           if last_is_blank && @src.check(HR_START)
@@ -71,6 +73,12 @@ module Kramdown
             item.value, indentation, content_re, lazy_re, indent_re =
               parse_first_list_line(@src[1].length, @src[2])
             list.children << item
+
+            if list_first && type == :ol
+              list_first = false
+              num = @src[1].scan(LIST_START_NUM_OL)
+              list.attr['start'] = num[0][0]
+            end
 
             item.value.sub!(self.class::LIST_ITEM_IAL) do
               parse_attribute_list($1, item.options[:ial] ||= {})

--- a/lib/kramdown/parser/kramdown/list.rb
+++ b/lib/kramdown/parser/kramdown/list.rb
@@ -77,7 +77,9 @@ module Kramdown
             if list_first && type == :ol
               list_first = false
               num = @src[1].scan(LIST_START_NUM_OL)
-              list.attr['start'] = num[0][0]
+	      if num && num[0][0] != "1"
+                list.attr['start'] = num[0][0]
+	      end
             end
 
             item.value.sub!(self.class::LIST_ITEM_IAL) do


### PR DESCRIPTION
## Background

I can see the difference between GitHub README and GitHub Pages like following ( Please see contents of Header5)

- README: https://github.com/ken-mu/cayman/blob/master/index.md
- GitHub Pages: https://ken-mu.github.io/cayman/

README lists ordered list (1. 2. 3.), but GitHub Pages lists only 1. at all.

## Changes

This change supports "start" attribution for <ol> HTML tag.
markdown:

```
# basic ol

1. test1
2. test2

# separated ol

1. test1

test

2. test2
3. test3

# ul

- test1
- test2
```

HTML:

```
<h1 id="basic-ol">basic ol</h1>

<ol>
  <li>test1</li>
  <li>test2</li>
</ol>

<h1 id="separated-ol">separated ol</h1>

<ol>
  <li>test1</li>
</ol>

<p>test</p>

<ol start="2">
  <li>test2</li>
  <li>test3</li>
</ol>

<h1 id="ul">ul</h1>

<ul>
  <li>test1</li>
  <li>test2</li>
</ul>
```

## Tests

I'll add testcases if necessary.