### PR TITLE
Add missing rexml dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -173,6 +173,7 @@ namespace :dev do
       s.executables = ['kramdown']
       s.default_executable = 'kramdown'
       s.required_ruby_version = '>= 2.3'
+      s.add_dependency "rexml"
       s.add_development_dependency 'minitest', '~> 5.0'
       s.add_development_dependency 'rouge'
       s.add_development_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
The next ruby version won't have rexml as a default gem, so it will need to be explicitly added as a dependency.

See https://bugs.ruby-lang.org/issues/16485#change-83794.