### PR TITLE
Reduce conversion of Symbol to String

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -47,13 +47,8 @@ module Kramdown
         @indent = 2
         @stack = []
 
-        @highlighter = options[:syntax_highlighter]
-        if @highlighter == :rouge
-          # assign a frozen string instead of converting Symbol to String for default use-case.
-          @highlighter = "rouge"
-        else
-          @highlighter = @highlighter.to_s
-        end
+        # stash string representation of symbol to avoid allocations from multiple interpolations.
+        @highlighter = options[:syntax_highlighter].to_s
       end
 
       # The mapping of element type to conversion method.

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -52,7 +52,7 @@ module Kramdown
           # assign a frozen string instead of converting Symbol to String for default use-case.
           @highlighter = "rouge"
         else
-          @highlighter = options[:syntax_highlighter].to_s
+          @highlighter = @highlighter.to_s
         end
       end
 

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -96,7 +96,7 @@ module Kramdown
             el.children.first.options[:ial]&.[](:refs)&.include?('standalone')
           convert_standalone_image(el.children.first, indent)
         else
-          format_as_block_html(el.type, el.attr, inner(el, indent), indent)
+          format_as_block_html("p", el.attr, inner(el, indent), indent)
         end
       end
 
@@ -143,7 +143,7 @@ module Kramdown
       end
 
       def convert_blockquote(el, indent)
-        format_as_indented_block_html(el.type, el.attr, inner(el, indent), indent)
+        format_as_indented_block_html("blockquote", el.attr, inner(el, indent), indent)
       end
 
       def convert_header(el, indent)
@@ -170,24 +170,26 @@ module Kramdown
         elsif !@footnote_location && el.options[:ial] && (el.options[:ial][:refs] || []).include?('footnotes')
           @footnote_location = ZERO_TO_ONETWENTYEIGHT.map { rand(36).to_s(36) }.join
         else
-          format_as_indented_block_html(el.type, el.attr, inner(el, indent), indent)
+          type = el.type == :ul ? "ul" : "ol"
+          format_as_indented_block_html(type, el.attr, inner(el, indent), indent)
         end
       end
       alias convert_ol convert_ul
 
       def convert_dl(el, indent)
-        format_as_indented_block_html(el.type, el.attr, inner(el, indent), indent)
+        format_as_indented_block_html("dl", el.attr, inner(el, indent), indent)
       end
 
       def convert_li(el, indent)
-        output = ' ' * indent << "<#{el.type}" << html_attributes(el.attr) << ">"
+        type = el.type == :li ? "li" : "dd"
+        output = ' ' * indent << "<#{type}" << html_attributes(el.attr) << ">"
         res = inner(el, indent)
         if el.children.empty? || (el.children.first.type == :p && el.children.first.options[:transparent])
           output << res << (res =~ /\n\Z/ ? ' ' * indent : '')
         else
           output << "\n" << res << ' ' * indent
         end
-        output << "</#{el.type}>\n"
+        output << "</#{type}>\n"
       end
       alias convert_dd convert_li
 
@@ -199,7 +201,7 @@ module Kramdown
             break
           end
         end if !attr['id'] && @stack.last.options[:ial] && @stack.last.options[:ial][:refs]
-        format_as_block_html(el.type, attr, inner(el, indent), indent)
+        format_as_block_html("dt", attr, inner(el, indent), indent)
       end
 
       def convert_html_element(el, indent)
@@ -274,7 +276,7 @@ module Kramdown
       end
 
       def convert_a(el, indent)
-        format_as_span_html(el.type, el.attr, inner(el, indent))
+        format_as_span_html("a", el.attr, inner(el, indent))
       end
 
       def convert_img(el, _indent)
@@ -321,7 +323,8 @@ module Kramdown
       end
 
       def convert_em(el, indent)
-        format_as_span_html(el.type, el.attr, inner(el, indent))
+        type = el.type == :em ? "em" : "strong"
+        format_as_span_html(type, el.attr, inner(el, indent))
       end
       alias convert_strong convert_em
 

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -46,6 +46,14 @@ module Kramdown
         @toc_code = nil
         @indent = 2
         @stack = []
+
+        @highlighter = options[:syntax_highlighter]
+        if @highlighter == :rouge
+          # assign a frozen string instead of converting Symbol to String for default use-case.
+          @highlighter = "rouge"
+        else
+          @highlighter = options[:syntax_highlighter].to_s
+        end
       end
 
       # The mapping of element type to conversion method.
@@ -403,7 +411,7 @@ module Kramdown
       # Add the syntax highlighter name to the 'class' attribute of the given attribute hash. And
       # overwrites or add a "language-LANG" part using the +lang+ parameter if +lang+ is not nil.
       def add_syntax_highlighter_to_class_attr(attr, lang = nil)
-        (attr['class'] = (attr['class'] || '') + " highlighter-#{@options[:syntax_highlighter]}").lstrip!
+        (attr['class'] = (attr['class'] || '') + " highlighter-#{@highlighter}").lstrip!
         attr['class'].sub!(/\blanguage-\S+|(^)/) { "language-#{lang}#{$1 ? ' ' : ''}" } if lang
       end
 

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -170,8 +170,7 @@ module Kramdown
         elsif !@footnote_location && el.options[:ial] && (el.options[:ial][:refs] || []).include?('footnotes')
           @footnote_location = ZERO_TO_ONETWENTYEIGHT.map { rand(36).to_s(36) }.join
         else
-          type = el.type == :ul ? "ul" : "ol"
-          format_as_indented_block_html(type, el.attr, inner(el, indent), indent)
+          format_as_indented_block_html(el.type, el.attr, inner(el, indent), indent)
         end
       end
       alias convert_ol convert_ul
@@ -181,8 +180,7 @@ module Kramdown
       end
 
       def convert_li(el, indent)
-        type = el.type == :li ? "li" : "dd"
-        output = ' ' * indent << "<#{type}" << html_attributes(el.attr) << ">"
+        output = ' ' * indent << "<#{el.type}" << html_attributes(el.attr) << ">"
         res = inner(el, indent)
         if el.children.empty? || (el.children.first.type == :p && el.children.first.options[:transparent])
           output << res << (res =~ /\n\Z/ ? ' ' * indent : '')
@@ -323,8 +321,7 @@ module Kramdown
       end
 
       def convert_em(el, indent)
-        type = el.type == :em ? "em" : "strong"
-        format_as_span_html(type, el.attr, inner(el, indent))
+        format_as_span_html(el.type, el.attr, inner(el, indent))
       end
       alias convert_strong convert_em
 

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -182,7 +182,7 @@ module Kramdown
         else
           output << "\n" << res << ' ' * indent
         end
-        output << "</#{type}>\n"
+        output << "</#{el.type}>\n"
       end
       alias convert_dd convert_li
 


### PR DESCRIPTION
Instead of interpolating `:rouge` (default and therefore more common scenario) to `"rouge"` multiple times when a `Kramdown::Document` is converted `to_html`, use a *frozen_string* to be used per instance.