### PR TITLE
Optimize `Kramdown::Document#to_html` calls

### DIFF
--- a/lib/kramdown/document.rb
+++ b/lib/kramdown/document.rb
@@ -106,10 +106,17 @@ module Kramdown
       end
     end
 
+    # Use Kramdown::Converter::Html class to convert this document into HTML.
+    def to_html
+      output, warnings = Kramdown::Converter::Html.convert(@root, @options)
+      @warnings.concat(warnings)
+      output
+    end
+
     # Check if a method is invoked that begins with +to_+ and if so, try to instantiate a converter
     # class (i.e. a class in the Kramdown::Converter module) and use it for converting the document.
     #
-    # For example, +to_html+ would instantiate the Kramdown::Converter::Html class.
+    # For example, +to_latex+ would instantiate the Kramdown::Converter::Latex class.
     def method_missing(id, *attr, &block)
       if id.to_s =~ /^to_(\w+)$/ && (name = Utils.camelize($1)) &&
           try_require('converter', name) && Converter.const_defined?(name)


### PR DESCRIPTION
**Disclaimer:** *This optimization is based on an assumption that the major use-case (of this project) is kramdown-to-HTML conversion.*

By having `:to_html` explicitly defined for the `Kramdown::Document` instances, the benefits are following:
- Reduce String allocations from converting `:to_html` to `"to_html"`.
- Reduce MatchData and String allocations from testing and extracting `"html"` from the method name and consequent conversion into `"Html"`.
- Reduce time spent to `require "kramdown/converter/html"` and consequent constant-lookup.

The optimization is to bypass steps above and call `Kramdown::Converter::Html.convert` directly. This is possible because `Kramdown::Converter::Html` is set up to be *autoloaded* if not available already.