### PR TITLE
Add WAI-ARIA role attributes to TOC and footnotes HTML

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -299,7 +299,7 @@ module Kramdown
           @footnotes << [name, el.value, number, 0]
           @footnotes_by_name[name] = @footnotes.last
         end
-        "<sup id=\"fnref:#{name}#{repeat}\">" \
+        "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
           "<a href=\"#fn:#{name}\" class=\"footnote\">" \
           "#{number}</a></sup>"
       end
@@ -411,6 +411,7 @@ module Kramdown
       def generate_toc_tree(toc, type, attr)
         sections = Element.new(type, nil, attr.dup)
         sections.attr['id'] ||= 'markdown-toc'
+        sections.attr['role'] ||= 'doc-toc'
         stack = []
         toc.each do |level, id, children|
           li = Element.new(:li, nil, nil, level: level)
@@ -478,7 +479,7 @@ module Kramdown
         result
       end
 
-      FOOTNOTE_BACKLINK_FMT = "%s<a href=\"#fnref:%s\" class=\"reversefootnote\">%s</a>"
+      FOOTNOTE_BACKLINK_FMT = "%s<a href=\"#fnref:%s\" class=\"reversefootnote\" role=\"doc-backlink\">%s</a>"
 
       # Return an HTML ordered list with the footnote content for the used footnotes.
       def footnote_content
@@ -488,7 +489,7 @@ module Kramdown
         backlink_text = escape_html(@options[:footnote_backlink], :text)
         while i < @footnotes.length
           name, data, _, repeat = *@footnotes[i]
-          li = Element.new(:li, nil, 'id' => "fn:#{name}")
+          li = Element.new(:li, nil, 'id' => "fn:#{name}", 'role' => 'doc-endnote')
           li.children = Marshal.load(Marshal.dump(data.children))
 
           para = nil
@@ -523,7 +524,7 @@ module Kramdown
         if ol.children.empty?
           ''
         else
-          format_as_indented_block_html('div', {class: "footnotes"}, convert(ol, 2), 0)
+          format_as_indented_block_html('div', {class: "footnotes", role: "doc-endnotes"}, convert(ol, 2), 0)
         end
       end
 

--- a/test/testcases/block/12_extension/options.html
+++ b/test/testcases/block/12_extension/options.html
@@ -10,12 +10,12 @@ some <span>*para*</span>
   <p>some <span><em>para</em></span></p>
 </div>
 
-<p>Some text<sup id="fnref:ab"><a href="#fn:ab" class="footnote">10</a></sup>.</p>
+<p>Some text<sup id="fnref:ab" role="doc-noteref"><a href="#fn:ab" class="footnote">10</a></sup>.</p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol start="10">
-    <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:ab" role="doc-endnote">
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/12_extension/options2.html
+++ b/test/testcases/block/12_extension/options2.html
@@ -1,10 +1,10 @@
 
-<p>Some text<sup id="fnref:ab"><a href="#fn:ab" class="footnote">1</a></sup>.</p>
+<p>Some text<sup id="fnref:ab" role="doc-noteref"><a href="#fn:ab" class="footnote">1</a></sup>.</p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:ab" role="doc-endnote">
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/14_table/table_with_footnote.html
+++ b/test/testcases/block/14_table/table_with_footnote.html
@@ -1,7 +1,7 @@
 <table>
   <tbody>
     <tr>
-      <td>this is <sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup></td>
+      <td>this is <sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">1</a></sup></td>
       <td>a table</td>
     </tr>
     <tr>
@@ -11,15 +11,15 @@
   </tbody>
 </table>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:1">
+    <li id="fn:1" role="doc-endnote">
       <p>Something</p>
 
       <blockquote>
         <p>special here</p>
       </blockquote>
-      <p><a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:1" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/16_toc/toc_exclude.html
+++ b/test/testcases/block/16_toc/toc_exclude.html
@@ -1,6 +1,6 @@
 <h1 class="no_toc" id="contents">Contents</h1>
 
-<ul id="markdown-toc">
+<ul id="markdown-toc" role="doc-toc">
   <li><a href="#header-level-1" id="markdown-toc-header-level-1">Header level 1</a>    <ul>
       <li><a href="#header-level-2" id="markdown-toc-header-level-2">Header level 2</a>        <ul>
           <li><a href="#header-level-3" id="markdown-toc-header-level-3">Header level 3</a>            <ul>

--- a/test/testcases/block/16_toc/toc_levels.html
+++ b/test/testcases/block/16_toc/toc_levels.html
@@ -1,4 +1,4 @@
-<ul id="markdown-toc">
+<ul id="markdown-toc" role="doc-toc">
   <li><a href="#header--level-2" id="markdown-toc-header--level-2">Header \` level 2</a>    <ul>
       <li><a href="#header-level-3" id="markdown-toc-header-level-3">Header level 3</a></li>
     </ul>

--- a/test/testcases/block/16_toc/toc_with_footnotes.html
+++ b/test/testcases/block/16_toc/toc_with_footnotes.html
@@ -1,13 +1,13 @@
-<ul id="markdown-toc">
+<ul id="markdown-toc" role="doc-toc">
   <li><a href="#header1-level-1" id="markdown-toc-header1-level-1">Header level 1</a></li>
 </ul>
 
-<h1 id="header1-level-1">Header<sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup> level 1</h1>
+<h1 id="header1-level-1">Header<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">1</a></sup> level 1</h1>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:1">
-      <p>Some footnote content here <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:1" role="doc-endnote">
+      <p>Some footnote content here <a href="#fnref:1" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/block/16_toc/toc_with_links.html
+++ b/test/testcases/block/16_toc/toc_with_links.html
@@ -2,7 +2,7 @@
 
 <h1 id="header-1"><a href="test.html">Header</a></h1>
 
-<ul id="markdown-toc">
+<ul id="markdown-toc" role="doc-toc">
   <li><a href="#header" id="markdown-toc-header">Header</a></li>
   <li><a href="#header-1" id="markdown-toc-header-1">Header</a></li>
 </ul>

--- a/test/testcases/span/04_footnote/backlink_inline.html
+++ b/test/testcases/span/04_footnote/backlink_inline.html
@@ -1,30 +1,30 @@
-<p>This is <sup id="fnref:paragraph"><a href="#fn:paragraph" class="footnote">1</a></sup><sup id="fnref:header"><a href="#fn:header" class="footnote">2</a></sup><sup id="fnref:blockquote"><a href="#fn:blockquote" class="footnote">3</a></sup><sup id="fnref:codeblock"><a href="#fn:codeblock" class="footnote">4</a></sup><sup id="fnref:list"><a href="#fn:list" class="footnote">5</a></sup><sup id="fnref:table"><a href="#fn:table" class="footnote">6</a></sup><sup id="fnref:hrule"><a href="#fn:hrule" class="footnote">7</a></sup><sup id="fnref:mathblock"><a href="#fn:mathblock" class="footnote">8</a></sup><sup id="fnref:html"><a href="#fn:html" class="footnote">9</a></sup></p>
+<p>This is <sup id="fnref:paragraph" role="doc-noteref"><a href="#fn:paragraph" class="footnote">1</a></sup><sup id="fnref:header" role="doc-noteref"><a href="#fn:header" class="footnote">2</a></sup><sup id="fnref:blockquote" role="doc-noteref"><a href="#fn:blockquote" class="footnote">3</a></sup><sup id="fnref:codeblock" role="doc-noteref"><a href="#fn:codeblock" class="footnote">4</a></sup><sup id="fnref:list" role="doc-noteref"><a href="#fn:list" class="footnote">5</a></sup><sup id="fnref:table" role="doc-noteref"><a href="#fn:table" class="footnote">6</a></sup><sup id="fnref:hrule" role="doc-noteref"><a href="#fn:hrule" class="footnote">7</a></sup><sup id="fnref:mathblock" role="doc-noteref"><a href="#fn:mathblock" class="footnote">8</a></sup><sup id="fnref:html" role="doc-noteref"><a href="#fn:html" class="footnote">9</a></sup></p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:paragraph">
+    <li id="fn:paragraph" role="doc-endnote">
 
-      <p>A paragraph <a href="#fnref:paragraph" class="reversefootnote">&#8617;</a></p>
+      <p>A paragraph <a href="#fnref:paragraph" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:header">
+    <li id="fn:header" role="doc-endnote">
 
-      <h1 id="a-header">A header <a href="#fnref:header" class="reversefootnote">&#8617;</a></h1>
+      <h1 id="a-header">A header <a href="#fnref:header" class="reversefootnote" role="doc-backlink">&#8617;</a></h1>
     </li>
-    <li id="fn:blockquote">
+    <li id="fn:blockquote" role="doc-endnote">
 
       <blockquote>
         <p>blockquote</p>
 
-        <p>paragraph <a href="#fnref:blockquote" class="reversefootnote">&#8617;</a></p>
+        <p>paragraph <a href="#fnref:blockquote" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
       </blockquote>
     </li>
-    <li id="fn:codeblock">
+    <li id="fn:codeblock" role="doc-endnote">
 
       <pre><code>codeblock
 </code></pre>
-      <p><a href="#fnref:codeblock" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:codeblock" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:list">
+    <li id="fn:list" role="doc-endnote">
 
       <ul>
         <li>item 1</li>
@@ -36,14 +36,14 @@
               <blockquote>
                 <p>blockquote</p>
 
-                <h1 id="header">header <a href="#fnref:list" class="reversefootnote">&#8617;</a></h1>
+                <h1 id="header">header <a href="#fnref:list" class="reversefootnote" role="doc-backlink">&#8617;</a></h1>
               </blockquote>
             </li>
           </ul>
         </li>
       </ul>
     </li>
-    <li id="fn:table">
+    <li id="fn:table" role="doc-endnote">
 
       <table>
         <tbody>
@@ -57,23 +57,23 @@
           </tr>
         </tbody>
       </table>
-      <p><a href="#fnref:table" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:table" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:hrule">
+    <li id="fn:hrule" role="doc-endnote">
 
       <hr />
-      <p><a href="#fnref:hrule" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:hrule" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:mathblock">
+    <li id="fn:mathblock" role="doc-endnote">
 
       <script type="math/tex; mode=display">x + 2</script>
-      <p><a href="#fnref:mathblock" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:mathblock" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:html">
+    <li id="fn:html" role="doc-endnote">
 
       <div>test
 </div>
-      <p><a href="#fnref:html" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:html" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/backlink_text.html
+++ b/test/testcases/span/04_footnote/backlink_text.html
@@ -1,9 +1,9 @@
-<p>Some footnote here<sup id="fnref:fn"><a href="#fn:fn" class="footnote">1</a></sup></p>
+<p>Some footnote here<sup id="fnref:fn" role="doc-noteref"><a href="#fn:fn" class="footnote">1</a></sup></p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:fn">
-      <p>Some text here <a href="#fnref:fn" class="reversefootnote">text &8617; &lt;img /&gt;</a></p>
+    <li id="fn:fn" role="doc-endnote">
+      <p>Some text here <a href="#fnref:fn" class="reversefootnote" role="doc-backlink">text &8617; &lt;img /&gt;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/footnote_nr.html
+++ b/test/testcases/span/04_footnote/footnote_nr.html
@@ -1,12 +1,12 @@
-<p>This is a footnote<sup id="fnref:ab"><a href="#fn:ab" class="footnote">35</a></sup>. And another<sup id="fnref:bc"><a href="#fn:bc" class="footnote">36</a></sup>.</p>
+<p>This is a footnote<sup id="fnref:ab" role="doc-noteref"><a href="#fn:ab" class="footnote">35</a></sup>. And another<sup id="fnref:bc" role="doc-noteref"><a href="#fn:bc" class="footnote">36</a></sup>.</p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol start="35">
-    <li id="fn:ab">
-      <p>Some text. <a href="#fnref:ab" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:ab" role="doc-endnote">
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:bc">
-      <p>Some other text. <a href="#fnref:bc" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:bc" role="doc-endnote">
+      <p>Some other text. <a href="#fnref:bc" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/footnote_prefix.html
+++ b/test/testcases/span/04_footnote/footnote_prefix.html
@@ -1,12 +1,12 @@
-<p>This is a<sup id="fnref:adf123-ab"><a href="#fn:adf123-ab" class="footnote">1</a></sup> footnote<sup id="fnref:adf123-ab:1"><a href="#fn:adf123-ab" class="footnote">1</a></sup>. And another<sup id="fnref:adf123-bc"><a href="#fn:adf123-bc" class="footnote">2</a></sup>.</p>
+<p>This is a<sup id="fnref:adf123-ab" role="doc-noteref"><a href="#fn:adf123-ab" class="footnote">1</a></sup> footnote<sup id="fnref:adf123-ab:1" role="doc-noteref"><a href="#fn:adf123-ab" class="footnote">1</a></sup>. And another<sup id="fnref:adf123-bc" role="doc-noteref"><a href="#fn:adf123-bc" class="footnote">2</a></sup>.</p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:adf123-ab">
-      <p>Some text. <a href="#fnref:adf123-ab" class="reversefootnote">&#8617;</a> <a href="#fnref:adf123-ab:1" class="reversefootnote">&#8617;<sup>2</sup></a></p>
+    <li id="fn:adf123-ab" role="doc-endnote">
+      <p>Some text. <a href="#fnref:adf123-ab" class="reversefootnote" role="doc-backlink">&#8617;</a> <a href="#fnref:adf123-ab:1" class="reversefootnote" role="doc-backlink">&#8617;<sup>2</sup></a></p>
     </li>
-    <li id="fn:adf123-bc">
-      <p>Some other text. <a href="#fnref:adf123-bc" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:adf123-bc" role="doc-endnote">
+      <p>Some other text. <a href="#fnref:adf123-bc" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/inside_footnote.html
+++ b/test/testcases/span/04_footnote/inside_footnote.html
@@ -1,17 +1,17 @@
-<p>Lorem ipsum<sup id="fnref:first"><a href="#fn:first" class="footnote">1</a></sup> dolor sit amet.</p>
+<p>Lorem ipsum<sup id="fnref:first" role="doc-noteref"><a href="#fn:first" class="footnote">1</a></sup> dolor sit amet.</p>
 
-<p>Lorem ipsum<sup id="fnref:second"><a href="#fn:second" class="footnote">2</a></sup> dolor sit amet.</p>
+<p>Lorem ipsum<sup id="fnref:second" role="doc-noteref"><a href="#fn:second" class="footnote">2</a></sup> dolor sit amet.</p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:first">
-      <p>Consecutur adisping.<sup id="fnref:third"><a href="#fn:third" class="footnote">3</a></sup> <a href="#fnref:first" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:first" role="doc-endnote">
+      <p>Consecutur adisping.<sup id="fnref:third" role="doc-noteref"><a href="#fn:third" class="footnote">3</a></sup> <a href="#fnref:first" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:second">
-      <p>Sed ut perspiciatis unde omnis. <a href="#fnref:second" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:second" role="doc-endnote">
+      <p>Sed ut perspiciatis unde omnis. <a href="#fnref:second" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:third">
-      <p>Sed ut. <a href="#fnref:third" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:third" role="doc-endnote">
+      <p>Sed ut. <a href="#fnref:third" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/markers.html
+++ b/test/testcases/span/04_footnote/markers.html
@@ -1,46 +1,46 @@
-<p>This is some *ref.<sup id="fnref:fn"><a href="#fn:fn" class="footnote">1</a></sup></p>
+<p>This is some *ref.<sup id="fnref:fn" role="doc-noteref"><a href="#fn:fn" class="footnote">1</a></sup></p>
 
 <blockquote>
-  <p>a blockquote <sup id="fnref:3"><a href="#fn:3" class="footnote">2</a></sup></p>
+  <p>a blockquote <sup id="fnref:3" role="doc-noteref"><a href="#fn:3" class="footnote">2</a></sup></p>
 </blockquote>
 
 <ul>
-  <li>and a list item <sup id="fnref:1"><a href="#fn:1" class="footnote">3</a></sup></li>
+  <li>and a list item <sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">3</a></sup></li>
 </ul>
 
-<h1>And a header<sup id="fnref:now"><a href="#fn:now" class="footnote">4</a></sup></h1>
+<h1>And a header<sup id="fnref:now" role="doc-noteref"><a href="#fn:now" class="footnote">4</a></sup></h1>
 
 <p>A marker without a definition [^without].</p>
 
-<p>A marker <sup id="fnref:empty"><a href="#fn:empty" class="footnote">5</a></sup> used twice<sup id="fnref:fn:1"><a href="#fn:fn" class="footnote">1</a></sup> and thrice<sup id="fnref:fn:2"><a href="#fn:fn" class="footnote">1</a></sup>.</p>
+<p>A marker <sup id="fnref:empty" role="doc-noteref"><a href="#fn:empty" class="footnote">5</a></sup> used twice<sup id="fnref:fn:1" role="doc-noteref"><a href="#fn:fn" class="footnote">1</a></sup> and thrice<sup id="fnref:fn:2" role="doc-noteref"><a href="#fn:fn" class="footnote">1</a></sup>.</p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:fn">
-      <p>Some foot note text&nbsp;<a href="#fnref:fn" class="reversefootnote">&#8617;</a>&nbsp;<a href="#fnref:fn:1" class="reversefootnote">&#8617;<sup>2</sup></a>&nbsp;<a href="#fnref:fn:2" class="reversefootnote">&#8617;<sup>3</sup></a></p>
+    <li id="fn:fn" role="doc-endnote">
+      <p>Some foot note text&nbsp;<a href="#fnref:fn" class="reversefootnote" role="doc-backlink">&#8617;</a>&nbsp;<a href="#fnref:fn:1" class="reversefootnote" role="doc-backlink">&#8617;<sup>2</sup></a>&nbsp;<a href="#fnref:fn:2" class="reversefootnote" role="doc-backlink">&#8617;<sup>3</sup></a></p>
     </li>
-    <li id="fn:3">
+    <li id="fn:3" role="doc-endnote">
       <p>other text
 with more lines</p>
 
       <blockquote>
         <p>and a quote</p>
       </blockquote>
-      <p><a href="#fnref:3" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:3" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:1">
-      <p>some <em>text</em>&nbsp;<a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:1" role="doc-endnote">
+      <p>some <em>text</em>&nbsp;<a href="#fnref:1" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:now">
+    <li id="fn:now" role="doc-endnote">
 
       <pre><code>code block
 continued here
 </code></pre>
-      <p><a href="#fnref:now" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:now" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
-    <li id="fn:empty">
+    <li id="fn:empty" role="doc-endnote">
 
-      <p><a href="#fnref:empty" class="reversefootnote">&#8617;</a></p>
+      <p><a href="#fnref:empty" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/placement.html
+++ b/test/testcases/span/04_footnote/placement.html
@@ -1,11 +1,11 @@
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:1">
-      <p>Footnote \` text&#160;<a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:1" role="doc-endnote">
+      <p>Footnote \` text&#160;<a href="#fnref:1" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>
 
-<p>Some para with a<sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup> footnote.</p>
+<p>Some para with a<sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">1</a></sup> footnote.</p>
 
 <p>And another para.</p>

--- a/test/testcases/span/04_footnote/regexp_problem.html
+++ b/test/testcases/span/04_footnote/regexp_problem.html
@@ -1,14 +1,14 @@
 <h1>Something</h1>
-<p>something<sup id="fnref:note1"><a href="#fn:note1" class="footnote">1</a></sup>.</p>
+<p>something<sup id="fnref:note1" role="doc-noteref"><a href="#fn:note1" class="footnote">1</a></sup>.</p>
 
 <h1>Footnotes</h1>
 
 <h1>Test</h1>
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:note1">
+    <li id="fn:note1" role="doc-endnote">
 
-      <p>A note&nbsp;<a href="#fnref:note1" class="reversefootnote">&#8617;</a></p>
+      <p>A note&nbsp;<a href="#fnref:note1" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>

--- a/test/testcases/span/04_footnote/without_backlink.html
+++ b/test/testcases/span/04_footnote/without_backlink.html
@@ -1,8 +1,8 @@
-<p>Some footnote here<sup id="fnref:fn"><a href="#fn:fn" class="footnote">1</a></sup></p>
+<p>Some footnote here<sup id="fnref:fn" role="doc-noteref"><a href="#fn:fn" class="footnote">1</a></sup></p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:fn">
+    <li id="fn:fn" role="doc-endnote">
       <p>Some text here</p>
     </li>
   </ol>

--- a/test/testcases/span/abbreviations/in_footnote.html
+++ b/test/testcases/span/abbreviations/in_footnote.html
@@ -1,9 +1,9 @@
-<p>There is a <abbr title="Text File">TXT</abbr> file here. <sup id="fnref:1"><a href="#fn:1" class="footnote">1</a></sup></p>
+<p>There is a <abbr title="Text File">TXT</abbr> file here. <sup id="fnref:1" role="doc-noteref"><a href="#fn:1" class="footnote">1</a></sup></p>
 
-<div class="footnotes">
+<div class="footnotes" role="doc-endnotes">
   <ol>
-    <li id="fn:1">
-      <p>A <abbr title="Text File">TXT</abbr> file. <a href="#fnref:1" class="reversefootnote">&#8617;</a></p>
+    <li id="fn:1" role="doc-endnote">
+      <p>A <abbr title="Text File">TXT</abbr> file. <a href="#fnref:1" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
     </li>
   </ol>
 </div>


### PR DESCRIPTION
This improves accessibility of the generated HTML.

See the documentation for the roles:

- [doc-backlink](https://www.w3.org/TR/dpub-aria-1.0/#doc-backlink)
- [doc-endnote](https://www.w3.org/TR/dpub-aria-1.0/#doc-endnote)
- [doc-endnotes](https://www.w3.org/TR/dpub-aria-1.0/#doc-endnotes)
- [doc-noteref](https://www.w3.org/TR/dpub-aria-1.0/#doc-noteref)
- [doc-toc](https://www.w3.org/TR/dpub-aria-1.0/#doc-toc)
