### PR TITLE
Don't require whitespace before closing ATX ### marks

### DIFF
--- a/lib/kramdown/parser/kramdown/header.rb
+++ b/lib/kramdown/parser/kramdown/header.rb
@@ -31,7 +31,7 @@ module Kramdown
       def parse_atx_header
         return false unless after_block_boundary?
         text, id = parse_header_contents
-        text.sub!(/[\t ]#+\z/, '') && text.rstrip!
+        text.sub!(/(?<!\\)#+\z/, '') && text.rstrip!
         return false if text.empty?
         add_header(@src["level"].length, text, id)
         true

--- a/test/testcases/block/04_header/atx_header.html
+++ b/test/testcases/block/04_header/atx_header.html
@@ -26,6 +26,12 @@
 ### not a header</p>
 </blockquote>
 
+<h1>header</h1>
+
+<h1>header</h1>
+
+<h1>header</h1>
+
 <h1>header #</h1>
 
 <h1>header</h1>

--- a/test/testcases/block/04_header/atx_header.text
+++ b/test/testcases/block/04_header/atx_header.text
@@ -23,6 +23,12 @@ paragraph
 > blockquote
 ### not a header
 
+# header #
+
+# header#
+
+#header#
+
 # header \#
 
 # header


### PR DESCRIPTION
Prior to 135f1fd, ATX headers with closing `###` marks did not require preceding whitespace. While this is a requirement in [GFM markdown](https://github.github.com/gfm/#atx-heading), the [original markdown spec](https://github.github.com/gfm/#atx-heading) doesn't require it.

This change therefore adds test cases to cover the reinstatement of this behaviour, and adjusts the trimming regex to exclude closing `###` marks only if they are preceded by a backslash (for which a test case already exists).

### Feedback

I'm not the most experienced with either different markdown formats or this project specifically, so I'd welcome any and all feedback. Specific questions, though:

1. I think this is safe from a performance POV, because the negative lookbehind only affects the capture scope, not the match logic. I'm sure people here have more regex perf experience than me, though; do you agree? Are there any benchmarks I should be running to validate my changes?
2. While I think the change I'm fixing was unintentional, it's not completely clear from the history that that's the case; are we happy to go with a looser interpretation of the original spec, and leave the stricter one to the GFM parser?

Thanks for taking the time to read this!