### PR TITLE
Optimize hash access by safe-navigating `Hash#dig`

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -89,7 +89,7 @@ module Kramdown
         if el.options[:transparent]
           inner(el, indent)
         elsif el.children.size == 1 && el.children.first.type == :img &&
-            el.children.first.options[:ial]&.[](:refs)&.include?('standalone')
+            el.children.first.options(dig :ial, :refs)&.include?('standalone')
           convert_standalone_image(el.children.first, indent)
         else
           format_as_block_html("p", el.attr, inner(el, indent), indent)
@@ -160,10 +160,10 @@ module Kramdown
       private_constant :ZERO_TO_ONETWENTYEIGHT
 
       def convert_ul(el, indent)
-        if !@toc_code && (el.options[:ial][:refs].include?('toc') rescue nil)
+        if !@toc_code && el.options.dig(:ial, :refs)&.include?('toc')
           @toc_code = [el.type, el.attr, ZERO_TO_ONETWENTYEIGHT.map { rand(36).to_s(36) }.join]
           @toc_code.last
-        elsif !@footnote_location && el.options[:ial] && (el.options[:ial][:refs] || []).include?('footnotes')
+        elsif !@footnote_location && el.options.dig(:ial, :refs)&.include?('footnotes')
           @footnote_location = ZERO_TO_ONETWENTYEIGHT.map { rand(36).to_s(36) }.join
         else
           format_as_indented_block_html(el.type, el.attr, inner(el, indent), indent)
@@ -189,12 +189,12 @@ module Kramdown
 
       def convert_dt(el, indent)
         attr = el.attr.dup
-        @stack.last.options[:ial][:refs].each do |ref|
+        @stack.last.options.dig(:ial, :refs)&.each do |ref|
           if ref =~ /\Aauto_ids(?:-([\w-]+))?/
             attr['id'] = "#{$1}#{basic_generate_id(el.options[:raw_text])}".lstrip
             break
           end
-        end if !attr['id'] && @stack.last.options[:ial] && @stack.last.options[:ial][:refs]
+        end if !attr['id'] && @stack.last.options.dig(:ial, :refs)
         format_as_block_html("dt", attr, inner(el, indent), indent)
       end
 
@@ -249,7 +249,7 @@ module Kramdown
         res = inner(el, indent)
         type = (@stack[-2].type == :thead ? :th : :td)
         attr = el.attr
-        alignment = @stack[-3].options[:alignment][@stack.last.children.index(el)]
+        alignment = @stack[-3].options.dig(:alignment, @stack.last.children.index(el))
         if alignment != :default
           attr = el.attr.dup
           attr['style'] = (attr.key?('style') ? "#{attr['style']}; " : '') + "text-align: #{alignment}"
@@ -337,7 +337,7 @@ module Kramdown
         raquo: [::Kramdown::Utils::Entities.entity('raquo')],
       } # :nodoc:
       def convert_typographic_sym(el, _indent)
-        if (result = @options[:typographic_symbols][el.value])
+        if (result = @options.dig(:typographic_symbols, el.value))
           escape_html(result, :text)
         else
           TYPOGRAPHIC_SYMS[el.value].map {|e| entity_to_str(e) }.join('')
@@ -363,8 +363,8 @@ module Kramdown
       end
 
       def convert_abbreviation(el, _indent)
-        title = @root.options[:abbrev_defs][el.value]
-        attr = @root.options[:abbrev_attr][el.value].dup
+        title = @root.options.dig(:abbrev_defs, el.value)
+        attr = @root.options.dig(:abbrev_attr, el.value).dup
         attr['title'] = title unless title.empty?
         format_as_span_html("abbr", attr, el.value)
       end

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -89,7 +89,7 @@ module Kramdown
         if el.options[:transparent]
           inner(el, indent)
         elsif el.children.size == 1 && el.children.first.type == :img &&
-            el.children.first.options.dig(:ial, :refs)&.include?('standalone')
+            el.children.first.options[:ial]&.[](:refs)&.include?('standalone')
           convert_standalone_image(el.children.first, indent)
         else
           format_as_block_html("p", el.attr, inner(el, indent), indent)
@@ -194,7 +194,7 @@ module Kramdown
             attr['id'] = "#{$1}#{basic_generate_id(el.options[:raw_text])}".lstrip
             break
           end
-        end if !attr['id'] && @stack.last.options.dig(:ial, :refs)
+        end if !attr['id'] && @stack.last.options[:ial] && @stack.last.options[:ial][:refs]
         format_as_block_html("dt", attr, inner(el, indent), indent)
       end
 
@@ -249,7 +249,7 @@ module Kramdown
         res = inner(el, indent)
         type = (@stack[-2].type == :thead ? :th : :td)
         attr = el.attr
-        alignment = @stack[-3].options.dig(:alignment, @stack.last.children.index(el))
+        alignment = @stack[-3].options[:alignment][@stack.last.children.index(el)]
         if alignment != :default
           attr = el.attr.dup
           attr['style'] = (attr.key?('style') ? "#{attr['style']}; " : '') + "text-align: #{alignment}"
@@ -363,8 +363,8 @@ module Kramdown
       end
 
       def convert_abbreviation(el, _indent)
-        title = @root.options.dig(:abbrev_defs, el.value)
-        attr = @root.options.dig(:abbrev_attr, el.value).dup
+        title = @root.options[:abbrev_defs][el.value]
+        attr = @root.options[:abbrev_attr][el.value].dup
         attr['title'] = title unless title.empty?
         format_as_span_html("abbr", attr, el.value)
       end

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -189,7 +189,7 @@ module Kramdown
 
       def convert_dt(el, indent)
         attr = el.attr.dup
-        @stack.last.options.dig(:ial, :refs)&.each do |ref|
+        @stack.last.options[:ial][:refs].each do |ref|
           if ref =~ /\Aauto_ids(?:-([\w-]+))?/
             attr['id'] = "#{$1}#{basic_generate_id(el.options[:raw_text])}".lstrip
             break
@@ -337,7 +337,7 @@ module Kramdown
         raquo: [::Kramdown::Utils::Entities.entity('raquo')],
       } # :nodoc:
       def convert_typographic_sym(el, _indent)
-        if (result = @options.dig(:typographic_symbols, el.value))
+        if (result = @options[:typographic_symbols][el.value])
           escape_html(result, :text)
         else
           TYPOGRAPHIC_SYMS[el.value].map {|e| entity_to_str(e) }.join('')

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -89,7 +89,7 @@ module Kramdown
         if el.options[:transparent]
           inner(el, indent)
         elsif el.children.size == 1 && el.children.first.type == :img &&
-            el.children.first.options(dig :ial, :refs)&.include?('standalone')
+            el.children.first.options.dig(:ial, :refs)&.include?('standalone')
           convert_standalone_image(el.children.first, indent)
         else
           format_as_block_html("p", el.attr, inner(el, indent), indent)

--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -426,9 +426,9 @@ module Kramdown
           end
         end.compact.join('')
         res = "toc" + (res.strip.empty? ? '' : " #{res}") if (el.type == :ul || el.type == :ol) &&
-          (el.options[:ial][:refs].include?('toc') rescue nil)
+          el.options.dig(:ial, :refs)&.include?('toc')
         res = "footnotes" + (res.strip.empty? ? '' : " #{res}") if (el.type == :ul || el.type == :ol) &&
-          (el.options[:ial][:refs].include?('footnotes') rescue nil)
+          el.options.dig(:ial, :refs)&.include?('footnotes')
         if el.type == :dl && el.options[:ial] && el.options[:ial][:refs]
           auto_ids = el.options[:ial][:refs].select {|ref| ref.start_with?('auto_ids') }.join(" ")
           res = auto_ids << (res.strip.empty? ? '' : " #{res}") unless auto_ids.empty?

--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -127,7 +127,7 @@ module Kramdown
       end
 
       def convert_ul(el, opts)
-        if !@data[:has_toc] && (el.options[:ial][:refs].include?('toc') rescue nil)
+        if !@data[:has_toc] && el.options.dig(:ial, :refs)&.include?('toc')
           @data[:has_toc] = true
           '\tableofcontents'
         else


### PR DESCRIPTION
By using `Hash#dig` in tandem with the safe navigation operator (both from Ruby 2.3), the logic doesn't need to `rescue and return nil` (therefore faster and avoids allocating `Thread::Backtrace`) nor have to assign to `[]` (on every call) to check if an object is included..

*Note: Only lines explicitly that `rescue and return nil` are patched in this pull request.*