### PR TITLE
Optimize preparation of options for Rouge

### DIFF
--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -43,10 +43,11 @@ module Kramdown::Converter::SyntaxHighlighter
       return if converter.data.key?(:syntax_highlighter_rouge)
 
       cache = converter.data[:syntax_highlighter_rouge] = {}
-      opts  = converter.options[:syntax_highlighter_opts].dup
 
-      span_opts  = opts.delete(:span)  || {}
-      block_opts = opts.delete(:block) || {}
+      opts = converter.options[:syntax_highlighter_opts].dup
+
+      span_opts = opts.delete(:span).dup || {}
+      block_opts = opts.delete(:block).dup || {}
       normalize_keys(span_opts)
       normalize_keys(block_opts)
 

--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -51,7 +51,9 @@ module Kramdown::Converter::SyntaxHighlighter
       normalize_keys(span_opts)
       normalize_keys(block_opts)
 
-      cache[:span]  = opts.merge(span_opts).update(wrap: false)
+      cache[:span] = opts.merge(span_opts)
+      cache[:span][:wrap] = false
+
       cache[:block] = opts.merge(block_opts)
     end
 

--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -43,18 +43,23 @@ module Kramdown::Converter::SyntaxHighlighter
       return if converter.data.key?(:syntax_highlighter_rouge)
 
       cache = converter.data[:syntax_highlighter_rouge] = {}
+      opts  = converter.options[:syntax_highlighter_opts].dup
 
-      opts = converter.options[:syntax_highlighter_opts].dup
-      span_opts = (opts.delete(:span) || {}).dup
-      block_opts = (opts.delete(:block) || {}).dup
-      [span_opts, block_opts].each do |hash|
-        hash.keys.each do |k|
-          hash[k.kind_of?(String) ? Kramdown::Options.str_to_sym(k) : k] = hash.delete(k)
-        end
-      end
+      span_opts  = opts.delete(:span)  || {}
+      block_opts = opts.delete(:block) || {}
+      normalize_keys(span_opts)
+      normalize_keys(block_opts)
 
-      cache[:span] = opts.merge(span_opts).update(wrap: false)
+      cache[:span]  = opts.merge(span_opts).update(wrap: false)
       cache[:block] = opts.merge(block_opts)
+    end
+
+    def self.normalize_keys(hash)
+      return if hash.empty?
+
+      hash.keys.each do |k|
+        hash[k.kind_of?(String) ? Kramdown::Options.str_to_sym(k) : k] = hash.delete(k)
+      end
     end
 
     def self.formatter_class(opts = {})


### PR DESCRIPTION
### Summary
- Replace array allocation `[span_opts, block_opts]` for every method call with serial calls to an extracted module method.
- Replace use of `Hash#update` and a static `{:wrap=>false}` with a direct mutation via `Hash#[]=` to avoid allocating `{:wrap=>false}` on every method call.
- Since `hash.keys` allocates an array even for empty hashes, add a guard-clause.

### Benchmark
(on Ruby 2.4, Windows)

```
highlighter options:  {:default_lang=>"plaintext", :guess_lang=>true}
Warming up --------------------------------------
     master     6.134k i/100ms
   proposed     7.358k i/100ms
Calculating -------------------------------------
     master     70.786k (A± 4.1%) i/s -    355.772k in   5.034089s
   proposed     89.577k (A± 4.7%) i/s -    448.838k in   5.021782s

Comparison:
   proposed:    89577.2 i/s
     master:    70786.3 i/s - 1.27x  slower
```
```
highlighter options:  {:default_lang=>"plaintext", :guess_lang=>true, :span=>{"foo"=>"bar"}, :block=>{"lorem"=>"ipsum"}}
Warming up --------------------------------------
     master     3.521k i/100ms
   proposed     3.737k i/100ms
Calculating -------------------------------------
     master     40.721k (A± 5.2%) i/s -    204.218k in   5.028392s
   proposed     43.369k (A± 8.7%) i/s -    216.746k in   5.030135s

Comparison:
   proposed:    43369.5 i/s
     master:    40720.8 i/s - same-ish: difference falls within error
```

### Memory profiles

```
highlighter options:  {:default_lang=>"plaintext", :guess_lang=>true}

memory-profile with master code through 1000 iterations

Total allocated: 1.24 MB (12000 objects)
Total retained:  576.00 B (3 objects)

memory-profile with proposed code through 1000 iterations

Total allocated: 848.00 kB (6000 objects)
Total retained:  576.00 B (3 objects)
```
```
highlighter options:  {:default_lang=>"plaintext", :guess_lang=>true, :span=>{"foo"=>"bar"}, :block=>{"lorem"=>"ipsum"}}

memory-profile with master code through 1000 iterations

Total allocated: 1.72 MB (14006 objects)
Total retained:  736.00 B (7 objects)

memory-profile with proposed code through 1000 iterations

Total allocated: 1.49 MB (12006 objects)
Total retained:  736.00 B (7 objects)
```