### PR TITLE
Return empty string if argument is an empty hash

### DIFF
--- a/lib/kramdown/utils/html.rb
+++ b/lib/kramdown/utils/html.rb
@@ -42,6 +42,8 @@ module Kramdown
 
       # Return the HTML representation of the attributes +attr+.
       def html_attributes(attr)
+        return '' if attr.empty?
+
         attr.map do |k, v|
           v.nil? || (k == 'id' && v.strip.empty?) ? '' : " #{k}=\"#{escape_html(v.to_s, :attribute)}\""
         end.join('')


### PR DESCRIPTION
When `attr == {}`, then end result to `Kramdown::Utils::Html#html_attributes(attr)` is always `""`, but involves allocation of intermediate empty array and the returned new empty string.

These allocations can be eliminated by returning a single frozen string every time `attr` is an empty hash.