### PR TITLE
Rendered Figure Captions

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -86,24 +86,28 @@ module Kramdown
       def convert_p(el, indent)
         if el.options[:transparent]
           inner(el, indent)
-        elsif el.children.size == 1 && el.children.first.type == :img &&
+        elsif el.children.first.type == :img &&
             el.children.first.options[:ial]&.[](:refs)&.include?('standalone')
-          convert_standalone_image(el.children.first, indent)
+          convert_standalone_image(el, indent)
         else
           format_as_block_html("p", el.attr, inner(el, indent), indent)
         end
       end
 
-      # Helper method used by +convert_p+ to convert a paragraph that only contains a single :img
+      # Helper method used by +convert_p+ to convert a paragraph that starts with a standalone :img
       # element.
       def convert_standalone_image(el, indent)
-        attr = el.attr.dup
-        figure_attr = {}
-        figure_attr['class'] = attr.delete('class') if attr.key?('class')
-        figure_attr['id'] = attr.delete('id') if attr.key?('id')
-        body = "#{' ' * (indent + @indent)}<img#{html_attributes(attr)} />\n" \
-          "#{' ' * (indent + @indent)}<figcaption>#{attr['alt']}</figcaption>\n"
-        format_as_indented_block_html("figure", figure_attr, body, indent)
+        first, *rest = el.children
+
+        body = +"#{' ' * (indent + @indent)}<img#{html_attributes(first.attr)} />\n"
+
+        if rest.size > 0
+          el.children = rest
+          cap = format_as_block_html("figcaption", {}, inner(el, indent), indent)
+          body << "#{' ' * (indent + @indent)}#{cap}"
+        end
+
+        format_as_indented_block_html("figure", el.attr, body, indent)
       end
 
       def convert_codeblock(el, indent)

--- a/test/testcases/block/03_paragraph/standalone_image.html
+++ b/test/testcases/block/03_paragraph/standalone_image.html
@@ -1,8 +1,23 @@
 <p>para</p>
 
-<figure class="class" id="id">
-  <img src="some.jpg" alt="standalone image" key="value" />
-  <figcaption>standalone image</figcaption>
+<figure>
+  <img src="some.jpg" alt="standalone image" id="id" class="class" key="value" />
+</figure>
+
+<figure id="figure-id" class="figure-class" figure-key="value">
+  <img src="some.jpg" alt="standalone image" id="id" class="class" key="value" />
+</figure>
+
+<figure id="figure-id" class="figure-class" figure-key="value">
+  <img src="some.jpg" alt="standalone image" id="id" class="class" key="value" />
+  <figcaption>
+Some caption text</figcaption>
+</figure>
+
+<figure>
+  <img src="some.jpg" alt="standalone image" />
+  <figcaption>
+Some <a href="/page">rendered</a> caption text</figcaption>
 </figure>
 
 <p>para</p>

--- a/test/testcases/block/03_paragraph/standalone_image.text
+++ b/test/testcases/block/03_paragraph/standalone_image.text
@@ -1,6 +1,16 @@
 para
 {:standalone}
 
-![standalone image](some.jpg){:#id .class key="value" standalone}
+![standalone image](some.jpg){: #id .class key="value" standalone}
+
+![standalone image](some.jpg){: #id .class key="value" standalone}
+{: #figure-id .figure-class figure-key="value"}
+
+![standalone image](some.jpg){: #id .class key="value" standalone}
+Some caption text
+{: #figure-id .figure-class figure-key="value"}
+
+![standalone image](some.jpg){:standalone}
+Some [rendered](/page) caption text
 
 para


### PR DESCRIPTION
This builds on the changes discussed in issue #48 about wrapping images in a `figure` tag instead of a `p`. The current implementation works well and doesn't add a lot of extra complication, but with a few small changes I think it could be more flexible without being more complex.

## What I was trying to accomplish
- Don't make things more complicated
- Allow rendering in captions
- Allow alt text without a caption
- Keep the ability to put an `#id` or a `.class` on the `<figure>`

## Changes
There are three inputs that are different with these changes:

### A standalone image by itself
```markdown
![alt text](some.jpg){: standalone #id .class attr="value"}
```
The `alt text` is not taken as the image caption, instead there is no caption at all. The `#id` and `.class` stay on the `<img>` instead of being copied to the `<figure>`. This is not a problem because a block IAL can fill this need.

### A standalone image with a block IAL
```markdown
![alt text](some.jpg){: standalone #id .class attr="value"}
{: #figure-id .figure-class figure-attr="value"}
```
The current implementation drops any attributes on the block instead of adding them to the figure. Implementing this seems like a nice solution to some of the concerns about id and class attributes on the image in #48.

### A standalone image with markdown after it
```markdown
![alt text](some.jpg){: standalone #id .class attr="value"}
Some [rendered](/link/location) image caption
{: .figure-class}
```
The current implementation does not make this a figure, but instead a paragraph with an inline image. Instead this would become a figure with any markup before the next blank line becoming a figure caption. This is similar to caption recommendations on [stack overflow](https://stackoverflow.com/a/30366422) and [Gitlab flavored markdown](https://about.gitlab.com/handbook/markdown-guide/#images) so it seems like people who have used such solutions would not find it all that surprising. It also allows rendering in the caption and allows the alt text to be different (another issue brought up in #48).