### PR TITLE
Add parent info to element opts + nested list bugfix

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -43,7 +43,8 @@ module Kramdown
         elsif el.block? &&
             ![:li, :dd, :dt, :td, :th, :tr, :thead, :tbody, :tfoot, :blank].include?(el.type) &&
             (el.type != :html_element || @stack.last.type != :html_element) &&
-            (el.type != :p || !el.options[:transparent])
+            (el.type != :p || !el.options[:transparent]) &&
+            !([:ul, :dl, :ol].include?(el.type) && opts[:parent] == :li)
           res << "\n"
         end
         res
@@ -59,6 +60,7 @@ module Kramdown
           options[:pprev] = (index <= 1 ? nil : el.children[index - 2])
           options[:next] = (index == el.children.length - 1 ? nil : el.children[index + 1])
           options[:nnext] = (index >= el.children.length - 2 ? nil : el.children[index + 2])
+          options[:parent] = el.type
           result << convert(inner_el, options)
         end
         @stack.pop


### PR DESCRIPTION
Element opts hash carrying info about the parent is generally useful.

Immediate use case is simple fix for a bug where nested lists don't realise they are nested, and hence newlines are added after the end of a nested list (within the main list) when this is of course unnecessary and can cause rendering issues.