### PR TITLE
Don't add newline after a nested list

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -43,7 +43,8 @@ module Kramdown
         elsif el.block? &&
             ![:li, :dd, :dt, :td, :th, :tr, :thead, :tbody, :tfoot, :blank].include?(el.type) &&
             (el.type != :html_element || @stack.last.type != :html_element) &&
-            (el.type != :p || !el.options[:transparent])
+            (el.type != :p || !el.options[:transparent]) &&
+            !([:ul, :dl, :ol].include?(el.type) && opts[:parent] == :li)
           res << "\n"
         end
         res
@@ -59,6 +60,7 @@ module Kramdown
           options[:pprev] = (index <= 1 ? nil : el.children[index - 2])
           options[:next] = (index == el.children.length - 1 ? nil : el.children[index + 1])
           options[:nnext] = (index >= el.children.length - 2 ? nil : el.children[index + 2])
+          options[:parent] = el.type
           result << convert(inner_el, options)
         end
         @stack.pop

--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -44,7 +44,7 @@ module Kramdown
             ![:li, :dd, :dt, :td, :th, :tr, :thead, :tbody, :tfoot, :blank].include?(el.type) &&
             (el.type != :html_element || @stack.last.type != :html_element) &&
             (el.type != :p || !el.options[:transparent]) &&
-            !([:ul, :dl, :ol].include?(el.type) && opts[:parent] == :li)
+            !([:ul, :dl, :ol].include?(el.type) && @stack.last.type == :li)
           res << "\n"
         end
         res
@@ -60,7 +60,6 @@ module Kramdown
           options[:pprev] = (index <= 1 ? nil : el.children[index - 2])
           options[:next] = (index == el.children.length - 1 ? nil : el.children[index + 1])
           options[:nnext] = (index >= el.children.length - 2 ? nil : el.children[index + 2])
-          options[:parent] = el.type
           result << convert(inner_el, options)
         end
         @stack.pop


### PR DESCRIPTION
Checks whether element is a list, and if that list is nested within another list (i.e. the list's parent is a list item). In this case we should not add another newline.

The change results in nested lists appearing as:

```
* First item
  * Sub item 1
    * Sub sub item
  * Sub item 2
* Second item
  * Sub item
```

rather than:

```
* First item
  * Sub item 1
    * Sub sub item

  * Sub item 2

* Second item
  * Sub item
```