### PR TITLE
fix: fix LaTeX entity conversion group location

### DIFF
--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -517,7 +517,7 @@ module Kramdown
         8194 => ['\hskip .5em\relax'],
         8195 => ['\quad'],
       } # :nodoc:
-      ENTITY_CONV_TABLE.each_value {|v| v[0] = "{}#{v[0]}" }
+      ENTITY_CONV_TABLE.each_value {|v| v[0] = "#{v[0]}{}" }
 
       def entity_to_latex(entity)
         text, package = ENTITY_CONV_TABLE[entity.code_point]

--- a/test/testcases/span/text_substitutions/entities.html
+++ b/test/testcases/span/text_substitutions/entities.html
@@ -3,4 +3,4 @@ As well \&amp; as this. Some &#343; other
 values may &#xAF; may also show but
 not st. like &amp;#xYZ;.</p>
 
-<p>This is BS&amp;T; done!</p>
+<p>This &lt;span&gt; is BS&amp;T; done!</p>

--- a/test/testcases/span/text_substitutions/entities.text
+++ b/test/testcases/span/text_substitutions/entities.text
@@ -3,4 +3,4 @@ As well \& as this. Some &#343; other
 values may &#xAF; may also show but
 not st. like &#xYZ;.
 
-This is BS&T; done!
+This &lt;span&gt; is BS&T; done!


### PR DESCRIPTION
This correctly places the `{}` group after the LaTeX commands used for conversion, rather than before. It appears this has been broken since edbd1fdf.

Also updates the span/text_substitutions/entities test to include `&lt;span&gt;`, which will be converted by the old converter to `{}\textlessspan{}\textgreater`, which should instead be `\textless{}span\textgreater{}`. The former will fail to compile, and should throw an error.