### PR TITLE
Bugfix: th and td elements can be empty

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -182,7 +182,7 @@ module Kramdown
         result << inner(el, opts) << "\n"
       end
 
-      HTML_TAGS_WITH_BODY = ['div', 'script', 'iframe', 'textarea']
+      HTML_TAGS_WITH_BODY = ['div', 'script', 'iframe', 'textarea', 'th', 'td']
 
       HTML_ELEMENT_TYPES = [:entity, :text, :html_element].freeze
       private_constant :HTML_ELEMENT_TYPES


### PR DESCRIPTION
It is possible and valid to have an empty `<td></td>` element (similarly with `<th>`) and would be invalid to close it as `<td />`.

This change adds `th` and `td` to the list of elements that must be explicitly closed even if they have no content.

It avoids a bug where the invalid output `<td />` will be generated if a table cell has no content.