### PR TITLE
Handle the Kramdown::Document.new input option like other options

### DIFF
--- a/lib/kramdown/document.rb
+++ b/lib/kramdown/document.rb
@@ -86,16 +86,11 @@ module Kramdown
     # Create a new Kramdown document from the string +source+ and use the provided +options+. The
     # options that can be used are defined in the Options module.
     #
-    # The special options key :input can be used to select the parser that should parse the
-    # +source+. It has to be the name of a class in the Kramdown::Parser module. For example, to
-    # select the kramdown parser, one would set the :input key to +Kramdown+. If this key is not
-    # set, it defaults to +Kramdown+.
-    #
     # The +source+ is immediately parsed by the selected parser so that the root element is
     # immediately available and the output can be generated.
     def initialize(source, options = {})
       @options = Options.merge(options).freeze
-      parser = (@options[:input] || 'kramdown').to_s
+      parser = @options[:input]
       parser = parser[0..0].upcase + parser[1..-1]
       try_require('parser', parser)
       if Parser.const_defined?(parser)

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -166,8 +166,8 @@ module Kramdown
     # ----------------------------
     # :section: Option Definitions
     #
-    # This sections contains all option definitions that are used by the included
-    # parsers/converters.
+    # This sections contains all option definitions passed to
+    # +Kramdown::Document.new+
     # ----------------------------
 
     define(:template, String, '', <<~EOF)
@@ -229,6 +229,15 @@ module Kramdown
 
       Default: ''
       Used by: HTML/Latex converter
+    EOF
+
+    define(:input, String, 'Kramdown', <<~EOF)
+      Select the parser that should parse the +source+. It has to be the name
+      of a class in the Kramdown::Parser module. The first letter is
+      automatically capitalised for you, so 'Kramdown' or 'kramdown' are both
+      accepted. To use the GitHub Flavored Markdown parser, pass 'GFM'.
+
+      Default: 'Kramdown'
     EOF
 
     define(:transliterated_header_ids, Boolean, false, <<~EOF)


### PR DESCRIPTION
I was trying to understand how to switch parsers, but I was confused when I
couldn't find `input` in the Options documentation:
https://kramdown.gettalong.org/options.html I was instead able to find it in
the kramdown-gfm documentation: https://github.com/kramdown/parser-gfm but I
still wanted to know what the default value was - and to check that it was a
supported part of the API.

It was only after looking at the source code for a while that I realised
it is documented under `Kramdown::Document.new` as a special case.

Aside from helping people with the problems I encountered above, this means
this argument is parsed and validated in a more standard way.