### PR TITLE
Restrict Rouge formatters to Rouge::Formatters namespace

### DIFF
--- a/lib/kramdown/converter/syntax_highlighter/rouge.rb
+++ b/lib/kramdown/converter/syntax_highlighter/rouge.rb
@@ -70,7 +70,7 @@ module Kramdown::Converter::SyntaxHighlighter
       when Class
         formatter
       when /\A[[:upper:]][[:alnum:]_]*\z/
-        ::Rouge::Formatters.const_get(formatter)
+        ::Rouge::Formatters.const_get(formatter, false)
       else
         # Available in Rouge 2.0 or later
         ::Rouge::Formatters::HTMLLegacy

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -21,16 +21,20 @@ begin
   end
 
   # custom formatter for tests
-  class RougeHTMLFormatters < Kramdown::Converter::SyntaxHighlighter::Rouge.formatter_class
+  module Rouge
+    module Formatters
+      class RougeHTMLFormatters < Kramdown::Converter::SyntaxHighlighter::Rouge.formatter_class
 
-    tag 'rouge_html_formatters'
+        tag 'rouge_html_formatters'
 
-    def stream(tokens, &b)
-      yield %(<div class="custom-class">)
-      super
-      yield %(</div>)
+        def stream(tokens, &b)
+          yield %(<div class="custom-class">)
+          super
+          yield %(</div>)
+        end
+
+      end
     end
-
   end
 rescue LoadError, SyntaxError, NameError
 end


### PR DESCRIPTION
ff0218aefcf00cd5a389e17e075d36cd46d011e2 added support for specifying custom Rouge formatters with the constraint that the formatter be in the`Rouge::Formatters` namespace, but it did not actually enforce this constraint. For example, this is valid:

```ruby
Rouge::Formatters.const_get('CSV')
=> CSV
```

Adding the `false` parameter to `const_get` prevents this:

```ruby
Rouge::Formatters.const_get('CSV', false)
NameError: uninitialized constant Rouge::Formatters::CSV
```