### PR TITLE
Allow the text surrounded by square brackets with IAL to convert to the span element.

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -277,6 +277,14 @@ module Kramdown
         "<img#{html_attributes(el.attr)} />"
       end
 
+      def convert_span(el, indent)
+        if el.attr.empty?
+          "[#{inner(el, indent)}]"
+        else
+          format_as_span_html('span', el.attr, inner(el, indent))
+        end
+      end
+
       def convert_codespan(el, _indent)
         attr = el.attr.dup
         lang = extract_code_language(attr)

--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -316,6 +316,10 @@ module Kramdown
         end
       end
 
+      def convert_span(el, opts)
+        "[#{inner(el, opts)}]"
+      end
+
       def convert_codespan(el, _opts)
         delim = (el.value.scan(/`+/).max || '') + '`'
         "#{delim}#{' ' if delim.size > 1}#{el.value}#{' ' if delim.size > 1}#{delim}"

--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -236,6 +236,10 @@ module Kramdown
         end
       end
 
+      def convert_span(el, opts)
+        "#{inner(el, opts)}"
+      end
+
       def convert_codespan(el, _opts)
         lang = extract_code_language(el.attr)
         if @options[:syntax_highlighter] == :minted &&

--- a/lib/kramdown/converter/latex.rb
+++ b/lib/kramdown/converter/latex.rb
@@ -237,7 +237,7 @@ module Kramdown
       end
 
       def convert_span(el, opts)
-        "#{inner(el, opts)}"
+        "[#{inner(el, opts)}]"
       end
 
       def convert_codespan(el, _opts)

--- a/lib/kramdown/converter/man.rb
+++ b/lib/kramdown/converter/man.rb
@@ -207,7 +207,7 @@ module Kramdown
       end
 
       def convert_span(el, opts)
-        inner(el, opts)
+        "[#{inner(el, opts)}]"
       end
 
       def convert_em(el, opts)

--- a/lib/kramdown/converter/man.rb
+++ b/lib/kramdown/converter/man.rb
@@ -206,6 +206,10 @@ module Kramdown
         warning("Images are not supported")
       end
 
+      def convert_span(el, opts)
+        inner(el, opts)
+      end
+
       def convert_em(el, opts)
         opts[:result] << '\fI'
         inner(el, opts)

--- a/lib/kramdown/element.rb
+++ b/lib/kramdown/element.rb
@@ -520,7 +520,7 @@ module Kramdown
     [:blank, :p, :header, :blockquote, :codeblock, :ul, :ol, :li, :dl, :dt, :dd,
      :table, :td, :hr].each {|b| CATEGORY[b] = :block }
     [:text, :a, :br, :img, :codespan, :footnote, :em, :strong, :entity, :typographic_sym,
-     :smart_quote, :abbreviation].each {|b| CATEGORY[b] = :span }
+     :smart_quote, :abbreviation, :span].each {|b| CATEGORY[b] = :span }
 
     # Return the category of +el+ which can be :block, :span or +nil+.
     #

--- a/lib/kramdown/parser/kramdown.rb
+++ b/lib/kramdown/parser/kramdown.rb
@@ -355,6 +355,7 @@ module Kramdown
       require 'kramdown/parser/kramdown/horizontal_rule'
       require 'kramdown/parser/kramdown/list'
       require 'kramdown/parser/kramdown/link'
+      require 'kramdown/parser/kramdown/span'
       require 'kramdown/parser/kramdown/extensions'
       require 'kramdown/parser/kramdown/footnote'
       require 'kramdown/parser/kramdown/html'

--- a/lib/kramdown/parser/kramdown/link.rb
+++ b/lib/kramdown/parser/kramdown/link.rb
@@ -100,7 +100,11 @@ module Kramdown
               warning("No link definition for link ID '#{link_id}' found on line #{start_line_number}")
             end
             @src.revert_pos(saved_pos)
-            add_text(result)
+            if @src.check(/./) == ']'
+              add_text(result)
+            else
+              parse_span
+            end
           end
           return
         end

--- a/lib/kramdown/parser/kramdown/span.rb
+++ b/lib/kramdown/parser/kramdown/span.rb
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+require 'kramdown'
+
+module Kramdown
+  module Parser
+    class Kramdown
+
+      # Parse the span at the current location.
+      def parse_span
+        start_line_number = @src.current_line_number
+        saved_pos = @src.save_pos
+
+        span_start = /(?:\[\s*?)/
+        result = @src.scan(span_start)
+        stop_re = /(?:\s*?\])/
+
+        el = Element.new(:span, nil, nil, :location => start_line_number)
+        found = parse_spans(el, stop_re) do
+          el.children.size > 0
+        end
+
+        if found
+          @src.scan(stop_re)
+          @tree.children << el
+        else
+          @src.revert_pos(saved_pos)
+          @src.pos += result.length
+          add_text(result)
+        end
+      end
+
+    end
+  end
+end

--- a/test/testcases/span/01_link/plain_span.html
+++ b/test/testcases/span/01_link/plain_span.html
@@ -1,0 +1,14 @@
+<p>Simple [Span]</p>
+
+<p>Simple <span id="id" class="class">Span</span></p>
+
+<p>Simple <a href="https://example.com/" id="id" class="class">Span</a></p>
+
+<p>Simple <a href="https://example.com/">Span</a></p>
+
+<p>Simple <a href="https://example.com/" id="id" class="class">Span</a></p>
+
+<p>Simple [Span]</p>
+
+<p>Simple [Span]{:#id .class}</p>
+

--- a/test/testcases/span/01_link/plain_span.text
+++ b/test/testcases/span/01_link/plain_span.text
@@ -1,0 +1,15 @@
+Simple [Span]
+
+Simple [Span]{:#id .class}
+
+Simple [Span](https://example.com/){:#id .class}
+
+Simple [Span][linkurl]
+
+Simple [Span][linkurl]{:#id .class}
+
+Simple \[Span\]
+
+Simple \[Span\]{:#id .class}
+
+[linkurl]: https://example.com/


### PR DESCRIPTION
I made it to convert the text surrounded in square brackets with IAL to a plain span element.
For example,  "This is [CLASS_A]{:.class-a} text. This is [NO IAL] text." is converted to "\<p\>This is \<span class="class-a"\>CLASS_A\</span\> text. This is [NO IAL] text.\</p\>".
I think this feature get kramdown more expressive and useful.
