### PR TITLE
Allocate a single dispatcher for `Html` Converters

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -32,6 +32,9 @@ module Kramdown
       include ::Kramdown::Utils::Html
       include ::Kramdown::Parser::Html::Constants
 
+      DISPATCHER = Hash.new { |h, k| h[k] = :"convert_#{k}" }
+      private_constant :DISPATCHER
+
       # The amount of indentation used when nesting HTML tags.
       attr_accessor :indent
 
@@ -49,7 +52,7 @@ module Kramdown
 
         # stash string representation of symbol to avoid allocations from multiple interpolations.
         @highlighter_class = " highlighter-#{options[:syntax_highlighter]}"
-        @dispatcher = Hash.new {|h, k| h[k] = :"convert_#{k}" }
+        @dispatcher = DISPATCHER
       end
 
       # Dispatch the conversion of the element +el+ to a +convert_TYPE+ method using the +type+ of


### PR DESCRIPTION
Mostly because I do not see the need to initialize a new Hash for every `Converter::Html` instance.

(kept the instance variable intact for backwards compatibility with extensions until next major version).