### PR TITLE
Make initial list label available for processor

### DIFF
--- a/lib/kramdown/parser/kramdown/list.rb
+++ b/lib/kramdown/parser/kramdown/list.rb
@@ -69,6 +69,7 @@ module Kramdown
             eob_found = true
             break
           elsif @src.scan(list_start_re)
+            list.options[:first_list_marker] ||= @src[1].strip
             item = Element.new(:li, nil, nil, location: start_line_number)
             item.value, indentation, content_re, lazy_re, indent_re =
               parse_first_list_line(@src[1].length, @src[2])


### PR DESCRIPTION
Making the initial list label available to the processor enables implementing behaviors such as deriving a starting number from the initial label.
(This should not impact any existing code.)