### PR TITLE
Allow the child element to be converted

### DIFF
--- a/lib/kramdown/converter/base.rb
+++ b/lib/kramdown/converter/base.rb
@@ -105,7 +105,7 @@ module Kramdown
           apply_template(converter, '')
         end
         result = converter.convert(tree)
-        if result.respond_to?(:encode!) && result.encoding != Encoding::BINARY
+        if tree.type == 'root' && result.respond_to?(:encode!) && result.encoding != Encoding::BINARY
           result.encode!(tree.options[:encoding] ||
                          (raise ::Kramdown::Error, "Missing encoding option on root element"))
         end

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -54,7 +54,12 @@ module Kramdown
 
       # Dispatch the conversion of the element +el+ to a +convert_TYPE+ method using the +type+ of
       # the element.
-      def convert(el, indent = -@indent)
+      def convert(el, indent = nil)
+        if el.type == :root
+          indent ||= -@indent
+        else
+          indent ||= 0
+        end
         send(@dispatcher[el.type], el, indent)
       end
 


### PR DESCRIPTION
## Purpose
I want to convert child element to HTML.

If each child element can be converted to HTML, then only a portion can be converted after the user has changed the structure of the parsed document.

```ruby
child = Kramdown::Document.new("some kramdown").root.children[0]
Kramdown::Converter::Html.convert(child)
# => ["<p>some kramdown</p>\n", []]
```

## Before fix
```ruby
child = Kramdown::Document.new("some kramdown").root.children[0]
Kramdown::Converter::Html.convert(child)
# Traceback (most recent call last):
#          ...
#          4: from /var/lib/gems/2.7.0/gems/kramdown-2.3.1/lib/kramdown/converter/base.rb:107:in `convert'
#          3: from /var/lib/gems/2.7.0/gems/kramdown-2.3.1/lib/kramdown/converter/html.rb:58:in `convert'
#          2: from /var/lib/gems/2.7.0/gems/kramdown-2.3.1/lib/kramdown/converter/html.rb:93:in `convert_p'
#          1: from /var/lib/gems/2.7.0/gems/kramdown-2.3.1/lib/kramdown/converter/html.rb:398:in `format_as_block_html'
# /var/lib/gems/2.7.0/gems/kramdown-2.3.1/lib/kramdown/converter/html.rb:398:in `*': negative argument (ArgumentError)
```