### PR TITLE
kramdown converter: Add list_indent option

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -28,6 +28,7 @@ module Kramdown
         @abbrevs = []
         @stack = []
         @list_indent = options[:list_indent] || 2
+        @list_spacing = ' ' * (@list_indent - 2)
       end
 
       def convert(el, opts = {indent: 0})
@@ -128,7 +129,7 @@ module Kramdown
 
       def convert_li(el, opts)
         sym, width = if @stack.last.type == :ul
-                       [+'* ', el.children.first && el.children.first.type == :codeblock ? 4 : @list_indent]
+                       ['* ' + @list_spacing, el.children.first && el.children.first.type == :codeblock ? 4 : @list_indent]
                      else
                        ["#{opts[:index] + 1}.".ljust(4), 4]
                      end
@@ -155,7 +156,7 @@ module Kramdown
       end
 
       def convert_dd(el, opts)
-        sym, width = +": ", (el.children.first && el.children.first.type == :codeblock ? 4 : @list_indent)
+        sym, width = ": " + @list_spacing, (el.children.first && el.children.first.type == :codeblock ? 4 : @list_indent)
         if (ial = ial_for_element(el))
           sym << ial << " "
         end

--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -27,6 +27,7 @@ module Kramdown
         @footnotes = []
         @abbrevs = []
         @stack = []
+        @list_indent = options[:list_indent] || 2
       end
 
       def convert(el, opts = {indent: 0})
@@ -127,7 +128,7 @@ module Kramdown
 
       def convert_li(el, opts)
         sym, width = if @stack.last.type == :ul
-                       [+'* ', el.children.first && el.children.first.type == :codeblock ? 4 : 2]
+                       [+'* ', el.children.first && el.children.first.type == :codeblock ? 4 : @list_indent]
                      else
                        ["#{opts[:index] + 1}.".ljust(4), 4]
                      end
@@ -154,7 +155,7 @@ module Kramdown
       end
 
       def convert_dd(el, opts)
-        sym, width = +": ", (el.children.first && el.children.first.type == :codeblock ? 4 : 2)
+        sym, width = +": ", (el.children.first && el.children.first.type == :codeblock ? 4 : @list_indent)
         if (ial = ial_for_element(el))
           sym << ial << " "
         end

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -197,6 +197,9 @@ class TestFiles < Minitest::Test
         kdtext = Kramdown::Document.new(File.read(text_file), options).to_kramdown
         html = Kramdown::Document.new(kdtext, options).to_html
         assert_equal(tidy_output(File.read(html_file)), tidy_output(html))
+        kdtext4 = Kramdown::Document.new(File.read(text_file), options.merge({list_indent: 4})).to_kramdown
+        html = Kramdown::Document.new(kdtext4, options).to_html
+        assert_equal(tidy_output(File.read(html_file)), tidy_output(html))
       end
     end
   end


### PR DESCRIPTION
Some markdown dialects need to have nested lists indented by 4 spaces.
The kramdown converter writes the 2 spaces needed by kramdown.
The option list_indent allows setting this to 4 so that other markdown
readers can use the output.