### PR TITLE
pass parser options into convert

### DIFF
--- a/lib/kramdown/converter/base.rb
+++ b/lib/kramdown/converter/base.rb
@@ -104,7 +104,7 @@ module Kramdown
         if !converter.options[:template].empty? && converter.apply_template_before?
           apply_template(converter, '')
         end
-        result = converter.convert(tree)
+        result = converter.convert(tree, converter.options)
         if result.respond_to?(:encode!) && result.encoding != Encoding::BINARY
           result.encode!(tree.options[:encoding] ||
                          (raise ::Kramdown::Error, "Missing encoding option on root element"))


### PR DESCRIPTION
When using the `.to_kramdown` converter, we were unable to pass the `:raw_text` option through to avoid escaping text such as `{foo_bar}` etc. This change passes all parser options through to the converter – not sure if we want that or another interface to pass the options through on `.to_kramdown` but this seemed okay with my basic testing. Looking for input/insight from maintainer to verify strategy here. 