### PR TITLE
Add new option, `footnote_link_text`

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -294,6 +294,7 @@ module Kramdown
       def convert_footnote(el, _indent)
         repeat = ''
         name = @options[:footnote_prefix] + el.options[:name]
+        link_text = @options[:footnote_link_text]
         if (footnote = @footnotes_by_name[name])
           number = footnote[2]
           repeat = ":#{footnote[3] += 1}"
@@ -303,9 +304,16 @@ module Kramdown
           @footnotes << [name, el.value, number, 0]
           @footnotes_by_name[name] = @footnotes.last
         end
-        "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
-          "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\">" \
-          "#{number}</a></sup>"
+        formatted_link_text = sprintf(link_text, number)
+        if (formatted_link_text == link_text)
+          "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
+            "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\">" \
+            "#{link_text}#{number}</a></sup>"
+        else
+          "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
+            "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\">" \
+            "#{formatted_link_text}</a></sup>"
+        end
       end
 
       def convert_raw(el, _indent)

--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -305,15 +305,9 @@ module Kramdown
           @footnotes_by_name[name] = @footnotes.last
         end
         formatted_link_text = sprintf(link_text, number)
-        if (formatted_link_text == link_text)
-          "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
-            "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\">" \
-            "#{link_text}#{number}</a></sup>"
-        else
-          "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
-            "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\">" \
-            "#{formatted_link_text}</a></sup>"
-        end
+        "<sup id=\"fnref:#{name}#{repeat}\" role=\"doc-noteref\">" \
+          "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\">" \
+          "#{formatted_link_text}</a></sup>"
       end
 
       def convert_raw(el, _indent)

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -586,6 +586,19 @@ module Kramdown
       Used by: HTML
     EOF
 
+    define(:footnote_link_text, String, '', <<~EOF)
+      The text used for the footnote number in a footnote link
+
+      This option can be used to add additional text to the footnote
+      link. It can be straight text; e.g. "footnote" would display
+      footnotes as "footnote 1". It can also be a format string, that passes
+      the footnote argument as the only argument to the format string.
+      "[footnote %s]" would display a footnote as "[footnote 1]".
+
+      Default: ''
+      Used by: HTML
+    EOF
+
     define(:remove_line_breaks_for_cjk, Boolean, false, <<~EOF)
       Specifies whether line breaks should be removed between CJK characters
 

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -586,18 +586,23 @@ module Kramdown
       Used by: HTML
     EOF
 
-    define(:footnote_link_text, String, '', <<~EOF)
+    define(:footnote_link_text, String, '%s', <<~EOF) do |val|
       The text used for the footnote number in a footnote link
 
       This option can be used to add additional text to the footnote
-      link. It can be straight text; e.g. "footnote" would display
-      footnotes as "footnote 1". It can also be a format string, that passes
-      the footnote argument as the only argument to the format string.
-      "[footnote %s]" would display a footnote as "[footnote 1]".
+      link. It should be a format string, and is passed the footnote
+      number as the only argument to the format string.
+      e.g. "[footnote %s]" would display as "[footnote 1]".
 
-      Default: ''
+      Default: '%s'
       Used by: HTML
     EOF
+      if !val.include?('%s')
+        raise Kramdown::Error, "option footnote_link_text needs to contain a '%s'"
+      end
+      val
+    end
+
 
     define(:remove_line_breaks_for_cjk, Boolean, false, <<~EOF)
       Specifies whether line breaks should be removed between CJK characters

--- a/test/testcases/span/04_footnote/footnote_link_text.html
+++ b/test/testcases/span/04_footnote/footnote_link_text.html
@@ -1,0 +1,12 @@
+<p>This is a<sup id="fnref:ab" role="doc-noteref"><a href="#fn:ab" class="footnote" rel="footnote">[footnote 1]</a></sup> footnote<sup id="fnref:ab:1" role="doc-noteref"><a href="#fn:ab" class="footnote" rel="footnote">[footnote 1]</a></sup>. And another<sup id="fnref:bc" role="doc-noteref"><a href="#fn:bc" class="footnote" rel="footnote">[footnote 2]</a></sup>.</p>
+
+<div class="footnotes" role="doc-endnotes">
+  <ol>
+    <li id="fn:ab" role="doc-endnote">
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote" role="doc-backlink">&#8617;</a> <a href="#fnref:ab:1" class="reversefootnote" role="doc-backlink">&#8617;<sup>2</sup></a></p>
+    </li>
+    <li id="fn:bc" role="doc-endnote">
+      <p>Some other text. <a href="#fnref:bc" class="reversefootnote" role="doc-backlink">&#8617;</a></p>
+    </li>
+  </ol>
+</div>

--- a/test/testcases/span/04_footnote/footnote_link_text.options
+++ b/test/testcases/span/04_footnote/footnote_link_text.options
@@ -1,0 +1,1 @@
+:footnote_link_text: "[footnote %s]"

--- a/test/testcases/span/04_footnote/footnote_link_text.text
+++ b/test/testcases/span/04_footnote/footnote_link_text.text
@@ -1,0 +1,4 @@
+This is a[^ab] footnote[^ab]. And another[^bc].
+
+[^ab]: Some text.
+[^bc]: Some other text.


### PR DESCRIPTION
`footnote_link_text` is a string that is directly inserted in front of the footnote number. It can also be a formatted string that the number is formatted into.

For example, if the string is "[footnote %s]", the footnote link will be "[footnote 1]".

It will determine it the option is a forat string by running it through `sprintf`; if the output is the same, then it's not a format string.

Also adds tests to make sure of the new output.

Fixes #692, and is a different attempt at #693.