### PR TITLE
Fix loading of config file with recent Rubies (Psych 4.0)

### DIFF
--- a/bin/kramdown
+++ b/bin/kramdown
@@ -112,9 +112,9 @@ end.parse!
 begin
   if config_file && File.exist?(config_file)
     config_file_options =
-      if Psych.method(:safe_load).parameters.include?(%i[key permitted_classes])
+      if YAML.method(:safe_load).parameters.include?(%i[key permitted_classes])
         YAML.safe_load(File.read(config_file), permitted_classes: [Symbol])
-      else # compatibility with Psych < 4.0
+      else # compatibility with Psych < 3.1.0
         YAML.safe_load(File.read(config_file), [Symbol])
       end
     case config_file_options

--- a/bin/kramdown
+++ b/bin/kramdown
@@ -111,7 +111,12 @@ end.parse!
 
 begin
   if config_file && File.exist?(config_file)
-    config_file_options = YAML.safe_load(File.read(config_file), [Symbol])
+    config_file_options =
+      if Psych.method(:safe_load).parameters.include?(%i[key permitted_classes])
+        YAML.safe_load(File.read(config_file), permitted_classes: [Symbol])
+      else # compatibility with Psych < 4.0
+        YAML.safe_load(File.read(config_file), [Symbol])
+      end
     case config_file_options
     when nil # empty configuration file except perhaps YAML header and comments
       # Nothing to do


### PR DESCRIPTION
Hello, 

I've been using the `bin/kramdown` utility recently with Ruby 3.2, and I hit an error when I use the `--config-file` option. 

----
Using Ruby 3.2, the following command would fail like this without the fix:

    > bin\kramdown --config-file .kramdown.yml -i GFM -o html README.md
    .../ruby-3.2-lean/lib/ruby/3.2.0/psych.rb:322:in `safe_load': wrong number of arguments (given 2, expected 1) (ArgumentError)
        from .../vendor/ruby/3.2.0/gems/kramdown-2.4.0/bin/kramdown:114:in `<top (required)>'
        from .../bin/kramdown.cmd:30:in `load'
        from .../bin/kramdown.cmd:30:in `<main>'
----

The kramdown script still uses the legacy `YAML.safe_load` API, which has been removed in Psych version 4.0 (cf. ruby/psych@07672270 and ruby/psych#533). Here's a fix that works for me, tested with Ruby v2.4, v2.7, v3.0, and v3.2. 

As for the fix, using the keyword argument directly instead of checking whether it is supported is also an option if you think there's no need to support Psych versions older than v3.1.0 (ruby/psych@682abf20). The comment in the commit should indeed have been `# compatibility with Psych < 3.1.0`.

