### PR TITLE
Fix deprecated interface for YAML.safe_load

### DIFF
--- a/bin/kramdown
+++ b/bin/kramdown
@@ -111,7 +111,7 @@ end.parse!
 
 begin
   if config_file && File.exist?(config_file)
-    config_file_options = YAML.safe_load(File.read(config_file), [Symbol])
+    config_file_options = YAML.safe_load(File.read(config_file), permitted_classes: [Symbol])
     case config_file_options
     when nil # empty configuration file except perhaps YAML header and comments
       # Nothing to do


### PR DESCRIPTION
Passing in the permitted classes as the second argument was deprecated in Psych 3 (https://github.com/ruby/psych/pull/378) and removed in Psych 4 (https://github.com/ruby/psych/pull/487).

Ruby 3.1 ships with Psych 4, so to make the code work for Ruby 2.7 and up, use the `permitted_classes` keyword argument.