### PR TITLE
auto_ids i18n: Non ASCII accents to ASCII

### DIFF
--- a/lib/kramdown/converter/base.rb
+++ b/lib/kramdown/converter/base.rb
@@ -235,7 +235,9 @@ module Kramdown
       # The basic version of the ID generator, without any special provisions for empty or unique
       # IDs.
       def basic_generate_id(str)
-        gen_id = str.gsub(/^[^a-zA-Z]+/, '')
+        gen_id = str.unicode_normalize(:nfkd)
+        gen_id.encode!('ASCII', replace: '')
+        gen_id.gsub!(/^[^a-zA-Z]+/, '')
         gen_id.tr!('^a-zA-Z0-9 -', '')
         gen_id.tr!(' ', '-')
         gen_id.downcase!

--- a/test/testcases/block/04_header/with_auto_ids.html
+++ b/test/testcases/block/04_header/with_auto_ids.html
@@ -16,6 +16,8 @@
 
 <h2 id="hallo-2">hallO</h2>
 
+<h1 id="aaaa">Âáàä</h1>
+
 <h1>Header without ID</h1>
 
 <h1 id="transliterated-day-la-vi-du">Transliterated: Đây-là-ví-dụ</h1>

--- a/test/testcases/block/04_header/with_auto_ids.text
+++ b/test/testcases/block/04_header/with_auto_ids.text
@@ -18,6 +18,8 @@ Not now
 
 ## hallO
 
+# Âáàä
+
 # Header without ID
 {: id=""}
 


### PR DESCRIPTION
At present, the utilization of auto_ids while writing headers with accented characters results in their removal rather than their conversion to the ASCII version. This patch solves the issue for various languages.

Example:

```markdown
# Hello
```
Results in id `hello`.

```markdown
# Déjà vu
```
Results in id `dj-vu`.

With the patch it would result in id `deja-vu`.