### PR TITLE
up rexml to a version that doesnt include the ddos vulnerability

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -172,7 +172,7 @@ namespace :dev do
       s.require_path = 'lib'
       s.executables = ['kramdown']
       s.required_ruby_version = '>= 2.3'
-      s.add_dependency "rexml"
+      s.add_dependency 'rexml',   '>= 3.2.7'
       s.add_development_dependency 'minitest', '~> 5.0'
       s.add_development_dependency 'rouge', '~> 3.0', '>= 3.26.0'
       s.add_development_dependency 'stringex', '~> 1.5.1'


### PR DESCRIPTION
REXML contains a denial of service vulnerability (CVE-2024-35176)

### Impact The REXML gem before 3.2.6 has a DoS vulnerability when it parses an XML that has many `<`s in an attribute value. If you need to parse untrusted XMLs, you many be impacted to this vulnerability. ### Patches The REXML gem 3.2.7 or later include the patch to fix this vulnerability. ### Workarounds Don't parse untrusted XMLs. ### References * https://www.ruby-lang.org/en/news/2024/05/16/dos-rexml-cve-2024-35176/


^ pasted from NewRelic