### PR TITLE
fix: cast source to a string before checking encoding

### DIFF
--- a/lib/kramdown/parser/base.rb
+++ b/lib/kramdown/parser/base.rb
@@ -89,7 +89,7 @@ module Kramdown
       # Modify the string +source+ to be usable by the parser (unifies line ending characters to
       # +\n+ and makes sure +source+ ends with a new line character).
       def adapt_source(source)
-        unless source.valid_encoding?
+        unless (source = source.to_s).valid_encoding?
           raise "The source text contains invalid characters for the used encoding #{source.encoding}"
         end
         source = source.encode('UTF-8')


### PR DESCRIPTION
Because of [this change](https://github.com/rails/rails/pull/51023) in rails, the template source that gets passed into here could be an `ActionView::OutputBuffer` which doesn't respond to `valid_encoding?`. The quick fix here is to cast it into a string first.