### PR TITLE
Prevent unnecessary escaping of numbers

### DIFF
--- a/lib/kramdown/converter/kramdown.rb
+++ b/lib/kramdown/converter/kramdown.rb
@@ -88,7 +88,7 @@ module Kramdown
       def convert_p(el, opts)
         w = @options[:line_width] - opts[:indent].to_s.to_i
         first, second, *rest = inner(el, opts).strip.gsub(/(.{1,#{w}})( +|$\n?)/, "\\1\n").split(/\n/)
-        first&.gsub!(/^(?:(#|>)|(\d+)\.|([+-]\s))/) { $1 || $3 ? "\\#{$1 || $3}" : "#{$2}\\." }
+        first&.gsub!(/^(?:(#|>)|(\d+)\.([\s\z])|([+-]\s))/) { $1 || $4 ? "\\#{$1 || $4}" : "#{$2}\\.#{$3}" }
         second&.gsub!(/^([=-]+\s*?)$/, "\\\1")
         res = [first, second, *rest].compact.join("\n") + "\n"
         res.gsub!(/^[ ]{0,3}:/, "\\:")

--- a/test/testcases/block/08_list/escaping.html
+++ b/test/testcases/block/08_list/escaping.html
@@ -14,4 +14,6 @@
 
 <p>1984. Was great!</p>
 
+<p>1984.5 is not a book.</p>
+
 <p>- This too!</p>

--- a/test/testcases/block/08_list/escaping.text
+++ b/test/testcases/block/08_list/escaping.text
@@ -14,4 +14,6 @@ I have read the book 1984.
 
 1984\. Was great!
 
+1984.5 is not a book.
+
 \- This too!


### PR DESCRIPTION
When a line starts with a number that ends with a period, e.g. `1984.`, it needs to be escaped, as otherwise markdown interprets it as a list.

However, if a line begins with a number that includes a period in it, e.g. `1984.5`, it does not need to be escaped, as it won't be interpreted as a list.