### PR TITLE
Change `<summary>` to use span content model instead of block

### DIFF
--- a/lib/kramdown/parser/html.rb
+++ b/lib/kramdown/parser/html.rb
@@ -38,10 +38,10 @@ module Kramdown
         HTML_CONTENT_MODEL_BLOCK = %w[address applet article aside blockquote body
                                       dd details div dl fieldset figure figcaption
                                       footer form header hgroup iframe li main
-                                      map menu nav noscript object section summary td]
+                                      map menu nav noscript object section td]
         HTML_CONTENT_MODEL_SPAN  = %w[a abbr acronym b bdo big button cite caption del dfn dt em
                                       h1 h2 h3 h4 h5 h6 i ins label legend optgroup p q rb rbc
-                                      rp rt rtc ruby select small span strong sub sup th tt]
+                                      rp rt rtc ruby select small span strong sub summary sup th tt]
         HTML_CONTENT_MODEL_RAW   = %w[script style math option textarea pre code kbd samp var]
         # The following elements are also parsed as raw since they need child elements that cannot
         # be expressed using kramdown syntax: colgroup table tbody thead tfoot tr ul ol

--- a/test/testcases/block/09_html/content_model/details.html
+++ b/test/testcases/block/09_html/content_model/details.html
@@ -1,0 +1,4 @@
+<details>
+  <summary>Summary</summary>
+  <p>Content</p>
+</details>

--- a/test/testcases/block/09_html/content_model/details.options
+++ b/test/testcases/block/09_html/content_model/details.options
@@ -1,0 +1,1 @@
+:parse_block_html: true

--- a/test/testcases/block/09_html/content_model/details.text
+++ b/test/testcases/block/09_html/content_model/details.text
@@ -1,0 +1,4 @@
+<details>
+  <summary>Summary</summary>
+  Content
+</details>


### PR DESCRIPTION
This PR proposes changing the content model for `<summary>` back to inline, ensuring cleaner output and a more intuitive user experience.

In HTML5, the `<summary>` element can be treated as either block or inline (phrasing) content. Currently, it's set as a block element, which can lead to formatting issues in general usage scenarios like the following.

## How to reproduce

Consider the following markdown file (summary.md).

```markdown

<details>
<summary>Hello</summary>
World
</details>
```

When processed with `bin/kramdown summary.md` with
the `--parse-block-html` option.

```console
$ bin/kramdown summary.md --parse-block-html
<h1 id="summary-test">Summary test</h1>

<details>
  <summary>
    <p>Hello&lt;/summary&gt;
World
&lt;/details&gt;</p>

  </summary>
</details>
Warning: Found no end tag for 'summary' (line 4) - auto-closing it
Warning: Found no end tag for 'details' (line 3) - auto-closing it
Warning: Found invalidly used HTML closing tag for 'summary' on line 4
Warning: Found invalidly used HTML closing tag for 'details' on line 6
```

### Expected output

```console
$ bin/kramdown summary.md --parse-block-html
<h1 id="summary-test">Summary test</h1>

<details>
  <summary>Hello</summary>
  <p>World</p>
</details>
```

## Suggestion

By treating `<summary>` as an inline span element rather than a block element, we can align with the expected output and common usage patterns. This change is compliant with the HTML5 specification, which allows `<summary>` to be treated as inline content.