### PR TITLE
Add new option, `footnote_link_title`

### DIFF
--- a/lib/kramdown/converter/html.rb
+++ b/lib/kramdown/converter/html.rb
@@ -315,8 +315,18 @@ module Kramdown
           @footnotes_by_name[name] = @footnotes.last
         end
         formatted_link_text = sprintf(@options[:footnote_link_text], number)
+        formatted_link_title = sprintf(@options[:footnote_link_title], number)
+
+        link_attr = {
+          href: "#fn:#{name}",
+          class: "footnote",
+          rel: "footnote",
+          role: "doc-noteref"
+        }
+        link_attr['title'] = formatted_link_title unless formatted_link_title.empty?
+
         "<sup id=\"fnref:#{name}#{repeat}\">" \
-          "<a href=\"#fn:#{name}\" class=\"footnote\" rel=\"footnote\" role=\"doc-noteref\">" \
+          "<a#{html_attributes(link_attr)}>" \
           "#{formatted_link_text}</a></sup>"
       end
 
@@ -490,7 +500,7 @@ module Kramdown
         result
       end
 
-      FOOTNOTE_BACKLINK_FMT = "%s<a href=\"#fnref:%s\" class=\"reversefootnote\" role=\"doc-backlink\">%s</a>"
+      FOOTNOTE_BACKLINK_FMT = "%s<a href=\"#fnref:%s\" class=\"reversefootnote\" role=\"doc-backlink\"%s>%s</a>"
 
       # Return an HTML ordered list with the footnote content for the used footnotes.
       def footnote_content
@@ -520,10 +530,20 @@ module Kramdown
 
           unless @options[:footnote_backlink].empty?
             nbsp = entity_to_str(ENTITY_NBSP)
-            value = sprintf(FOOTNOTE_BACKLINK_FMT, (insert_space ? nbsp : ''), name, backlink_text)
+            number = @footnotes_by_name[name][2]
+            backlink_title_attr = @options[:footnote_backlink_title].empty? ? '' : " title=\"#{escape_html(sprintf(@options[:footnote_backlink_title], number))}\""
+            value = sprintf(FOOTNOTE_BACKLINK_FMT,
+                            (insert_space ? nbsp : ''),
+                            name,
+                            backlink_title_attr,
+                            backlink_text)
             para.children << Element.new(:raw, value)
             (1..repeat).each do |index|
-              value = sprintf(FOOTNOTE_BACKLINK_FMT, nbsp, "#{name}:#{index}",
+              backlink_title_attr = @options[:footnote_backlink_title].empty? ? '' : " title=\"#{escape_html(sprintf(@options[:footnote_backlink_title], number))}\""
+              value = sprintf(FOOTNOTE_BACKLINK_FMT,
+                              nbsp,
+                              "#{name}:#{index}",
+                              backlink_title_attr,
                               "#{backlink_text}<sup>#{index + 1}</sup>")
               para.children << Element.new(:raw, value)
             end

--- a/lib/kramdown/options.rb
+++ b/lib/kramdown/options.rb
@@ -613,6 +613,38 @@ module Kramdown
       val
     end
 
+    define(:footnote_link_title, String, '', <<~EOF) do |val|
+      The tooltip on the footnote link
+
+      This option can be used to add the title attribute on footnote
+      links. It should be a format string, and is passed the footnote
+      number as the only argument to the format string.
+      e.g. "Jump to footnote %s" would display as "Jump to footnote 1".
+
+      Tooltips must be plain text. Any special HTML characters will be escaped.
+
+      Default: ''
+      Used by: HTML
+    EOF
+      if !val.empty? && !val.include?('%s')
+        raise Kramdown::Error, "option footnote_link_title needs to contain a '%s'"
+      end
+      val
+    end
+
+    define(:footnote_backlink_title, String, '', <<~EOF)
+      The tooltip on the footnote backlink
+
+      This option can be used to change the title attribute on footnote
+      backlinks. If set to a format string, the footnote number is available as
+      first and only argument to the format string.
+      e.g. "Jump back to [%s] in the text" would display as "Jump back to [1] in the text".
+
+      Tooltips must be plain text. Any special HTML characters will be escaped.
+
+      Default: ''
+      Used by: HTML
+    EOF
 
     define(:remove_line_breaks_for_cjk, Boolean, false, <<~EOF)
       Specifies whether line breaks should be removed between CJK characters

--- a/test/test_files.rb
+++ b/test/test_files.rb
@@ -243,6 +243,7 @@ class TestFiles < Minitest::Test
       'test/testcases/block/09_html/standalone_image_in_div.html', # bc of standalone image
       'test/testcases/block/09_html/processing_instruction.html', # bc of PI
       'test/testcases/block/04_header/with_header_links.html', # bc of header_links option
+      'test/testcases/span/04_footnote/footnote_link_title.html', # bc of attribute ordering
     ].compact
     Dir[File.dirname(__FILE__) + '/testcases/**/*.html'].each do |html_file|
       next if EXCLUDE_HTML_KD_FILES.any? {|f| html_file =~ /#{f}$/ }

--- a/test/testcases/span/04_footnote/footnote_link_title.html
+++ b/test/testcases/span/04_footnote/footnote_link_title.html
@@ -1,0 +1,12 @@
+<p>This is a footnote. <sup id="fnref:ab"><a href="#fn:ab" class="footnote" rel="footnote" role="doc-noteref" title="Jump to footnote 1">[1]</a></sup> And another. <sup id="fnref:bc"><a href="#fn:bc" class="footnote" rel="footnote" role="doc-noteref" title="Jump to footnote 2">[2]</a></sup></p>
+
+<div class="footnotes" role="doc-endnotes">
+  <ol>
+    <li id="fn:ab">
+      <p>Some text. <a href="#fnref:ab" class="reversefootnote" role="doc-backlink" title="Jump back to reference 1">&#8617;</a></p>
+    </li>
+    <li id="fn:bc">
+      <p>Some other text. <a href="#fnref:bc" class="reversefootnote" role="doc-backlink" title="Jump back to reference 2">&#8617;</a></p>
+    </li>
+  </ol>
+</div>

--- a/test/testcases/span/04_footnote/footnote_link_title.options
+++ b/test/testcases/span/04_footnote/footnote_link_title.options
@@ -1,0 +1,3 @@
+:footnote_link_text: "[%s]"
+:footnote_link_title: "Jump to footnote %s"
+:footnote_backlink_title: "Jump back to reference %s"

--- a/test/testcases/span/04_footnote/footnote_link_title.text
+++ b/test/testcases/span/04_footnote/footnote_link_title.text
@@ -1,0 +1,4 @@
+This is a footnote. [^ab] And another. [^bc]
+
+[^ab]: Some text.
+[^bc]: Some other text.


### PR DESCRIPTION
Add the option for an accessible tooltip on footnote links and backlinks.

Examples:
* Daring Fireball  `<a href="#…" title="Jump back to footnote 1 in the text.">↩︎︎</a>`,
 https://daringfireball.net/2025/01/one_bit_of_anecdata_that_the_web_is_languishing#fn1-2025-01-13
* Wikipedia `<a href="#…" title="Jump up">^</a>`,
 https://en.wikipedia.org/wiki/Tower_Bridge#References
* WordPress `<a href="#…" title="Jump back">↩︎</a>`,
 https://timotijhof.net/posts/2022/internet-archive-crawling/#fn1